### PR TITLE
Ensure that the downloaded version of Jenkins is always up-to-date. Fixes issue #9

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -7,10 +7,8 @@ JENKINS_WAR=jenkins.war
 export JENKINS_HOME=$(dirname $BASH_SOURCE)/jenkins-master
 
 
-if [ ! -e $JENKINS_WAR ]; then
-  echo "Downloading Jenkins $JENKINS_VERSION from $JENKINS_URL"
-  curl --location $JENKINS_URL -o $JENKINS_WAR
-fi
+echo "Downloading Jenkins $JENKINS_VERSION from $JENKINS_URL"
+curl --location $JENKINS_URL -z $JENKINS_WAR -o $JENKINS_WAR
 
 # TODO: Start Jenkins as daemon
 java -jar $JENKINS_WAR


### PR DESCRIPTION
So you were right. Adding '-z FILENAME' is the solution here and works fine. I only was confused by the initial warning you will get, but that's expected as given by the curl documentation.
