### PR TITLE
Add channel to ondemand update tests

### DIFF
--- a/config/ondemand/update-mac.ini
+++ b/config/ondemand/update-mac.ini
@@ -1,6 +1,7 @@
 [testrun]
 script=update
 target-build-id=20120403211507
+channel=release
 
 [mac 10.6 64bit]
 platform=mac

--- a/jenkins-master/jobs/ondemand_update/config.xml
+++ b/jenkins-master/jobs/ondemand_update/config.xml
@@ -53,6 +53,11 @@
           <defaultValue></defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
+          <name>CHANNEL</name>
+          <description>Update channel</description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>VERSION</name>
           <description>The version of Firefox.</description>
           <defaultValue></defaultValue>
@@ -93,7 +98,7 @@
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder>
-      <commandLine>mozmill-env/run mozmill-automation/testrun_update.py --target-buildid=$TARGET_BUILD_ID --no-fallback --junit=report.xml --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env/run mozmill-automation/testrun_update.py --target-buildid=$TARGET_BUILD_ID --no-fallback --channel=$CHANNEL --junit=report.xml --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/trigger-ondemand/workspace/trigger.py
+++ b/jenkins-master/jobs/trigger-ondemand/workspace/trigger.py
@@ -78,6 +78,7 @@ def main():
 
                 if script == 'update' and 'target-build-id' in testrun:
                     parameters['TARGET_BUILD_ID'] = testrun['target-build-id']
+                    parameters['CHANNEL'] = testrun['channel']
                 elif script == 'endurance':
                     if 'delay' in testrun:
                         parameters['DELAY'] = testrun['delay']


### PR DESCRIPTION
This has a limitation in that the channel must be specified in the command line. We will need to revisit to work out how best to allow falling back to automatically selecting the channel.
