### PR TITLE
Fixed regular expression for builds with ESR version suffix

### DIFF
--- a/jenkins-master/jobs/trigger-ondemand/workspace/trigger.py
+++ b/jenkins-master/jobs/trigger-ondemand/workspace/trigger.py
@@ -53,8 +53,8 @@ def main():
             locales = [ ]
             build_type = 'release'
 
-            # Expression to parse versions like: '5.0', '5.0#3', '5.0b1', '5.0b2#1'
-            pattern = re.compile(r'(?P<version>[\d\.]+(?:\w\d+)?)(?:#(?P<build>\d+))?')
+            # Expression to parse versions like: '5.0', '5.0#3', '5.0b1', '5.0b2#1', '10.0esr#1', '10.0.4esr#1'
+            pattern = re.compile(r'(?P<version>[\d\.]+(?:\w+)?)(?:#(?P<build>\d+))?')
             try:
                 (version, build) = pattern.match(entry).group('version', 'build')
                 locales = config.get(section, entry).split(' ')


### PR DESCRIPTION
This was fixed in testrun_release.py in [this commit](http://hg.mozilla.org/qa/mozmill-automation/rev/2cdea2b5eff3), however the fix doesn't work with x.x.x version numbers.

This fix basically removes the necessity for a single character followed by one or more digits. It can now be any number of characters preceding an optional '#'.
