### PR TITLE
Pin the dependency versions in setup/requirements.txt. Fixes #66

### DIFF
--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -1,3 +1,3 @@
-mercurial
-python-jenkins
-MozillaPulse
+mercurial==2.1
+python-jenkins==0.2
+MozillaPulse==.5


### PR DESCRIPTION
This takes the version of pypi packages we currently use on production. If we want to upgrade we should test it deeply first. I would like to wait until we have a staging system.
