### PR TITLE
Increase memory allocation for Jenkins and enabled incremental collection

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -11,5 +11,5 @@ echo "Downloading Jenkins $JENKINS_VERSION from $JENKINS_URL"
 curl --location $JENKINS_URL -z $JENKINS_WAR -o $JENKINS_WAR
 
 # TODO: Start Jenkins as daemon
-java -jar $JENKINS_WAR
+java -jar -Xms2g -Xmx2g -XX:MaxPermSize=512M -Xincgc $JENKINS_WAR
 


### PR DESCRIPTION
This should improve the situation with our recent OutOfMemory issues.
## Xmx/Xms

> - The -Xmx value determines the size of the heap to reserve at JVM initialization.
> - The -Xms value is the space in memory that is committed to the VM at init. The JVM can grow to the size of -Xmx.
> 
> Set -Xms and -Xmx close to each other or equal for a faster startup (removes constant resizing of JVM). But if you make a poor choice the JVM can't compensate for it.

From http://www.petefreitag.com/articles/gctuning/
## XX:MaxPermSize:

> PermSize is additional separate heap space to the -Xmx value set by the user. The section of the heap reserved for the permanent generation holds all of the reflective data for the JVM. You should adjust the size accordingly if your application dynamically load and unload a lot of classes in order to optimize the performance. Basically, he heap stores the objects and the perm gen keeps information about the objects inside of it. Therefore, the larger the heap, the larger the perm gen needs to be.
> 
> By default, MaxPermSize will be 32mb for -client and 64mb for -server. However, if you do not set both PermSize and MaxPermSize, the overall heap will not increase unless it is needed. When you set both PermSize and MaxPermSize, for example, 192mb, the extra heap space will get allocated when it startup and will stay allocated.

From http://www.dbuggr.com/smallwei/permsize-maxpermsize-work-java/
## Xincg

Incremental Low Pause Collector

From: http://www.petefreitag.com/articles/gctuning/
