### PR TITLE
Don't use CNAME domain entry to limit failures if host is not available. r=dhunt

### DIFF
--- a/config/daily.json
+++ b/config/daily.json
@@ -44,7 +44,7 @@
                     "transform": "get_platform_identifier"
                 },
                 "REPORT_URL": {
-                    "value": "http://mozmill-ci.blargon7.com/db/"
+                    "value": "http://mozauto.iriscouch.com/mozmill-ci"
                 }
             },
             "endurance": {

--- a/config/l10n.json
+++ b/config/l10n.json
@@ -40,7 +40,7 @@
                     "transform": "get_platform_identifier"
                 },
                 "REPORT_URL": {
-                    "value": "http://mozmill-ci.blargon7.com/db/"
+                    "value": "http://mozauto.iriscouch.com/mozmill-ci"
                 }
             }
         },

--- a/config/ondemand/functional-all.ini
+++ b/config/ondemand/functional-all.ini
@@ -1,5 +1,6 @@
 [testrun]
 script=functional
+report=http://mozauto.iriscouch.com/mozmill-ondemand
 
 [mac 10.5 64bit]
 platform=mac

--- a/config/ondemand/l10n-linux.ini
+++ b/config/ondemand/l10n-linux.ini
@@ -1,5 +1,6 @@
 [testrun]
 script=l10n
+report=http://mozauto.iriscouch.com/mozmill-ondemand
 
 [linux ubuntu 32bit]
 platform=linux

--- a/config/ondemand/l10n-mac.ini
+++ b/config/ondemand/l10n-mac.ini
@@ -1,5 +1,6 @@
 [testrun]
 script=l10n
+report=http://mozauto.iriscouch.com/mozmill-ondemand
 
 [mac 10.7 64bit]
 platform=mac

--- a/config/ondemand/update-mac.ini
+++ b/config/ondemand/update-mac.ini
@@ -1,5 +1,6 @@
 [testrun]
 script=update
+report=http://mozauto.iriscouch.com/mozmill-ondemand
 target-build-id=20120403211507
 channel=release
 

--- a/config/release.json
+++ b/config/release.json
@@ -44,7 +44,7 @@
                     "transform": "get_platform_identifier"
                 },
                 "REPORT_URL": {
-                    "value": "http://mozmill-ci.blargon7.com/db/"
+                    "value": "http://mozauto.iriscouch.com/mozmill-ci"
                 },
                 "VERSION": {
                     "key": "version"

--- a/jenkins-master/jobs/trigger-ondemand/workspace/trigger.py
+++ b/jenkins-master/jobs/trigger-ondemand/workspace/trigger.py
@@ -38,7 +38,7 @@ def main():
     testrun = testrun
 
     script = testrun['script']
-    report_url = 'report' in testrun and testrun['report'] or 'http://mozmill-ondemand.blargon7.com/db/'
+    report_url = 'report' in testrun and testrun['report'] or None
 
     # Iterate through all target nodes
     for section in config.sections():


### PR DESCRIPTION
We already had it a couple of times that the DNS entry was not working for mozmill-ci.blargon7.com and that caused a failure in sending the report. We could remove this extra dependency by simply reporting against the real real couchdb host.
