### PR TITLE
Only keep the last 100 builds for testrun jobs

### DIFF
--- a/jenkins-master/jobs/get_mozmill-automation/config.xml
+++ b/jenkins-master/jobs/get_mozmill-automation/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description></description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/get_mozmill-environments/config.xml
+++ b/jenkins-master/jobs/get_mozmill-environments/config.xml
@@ -2,6 +2,12 @@
 <matrix-project>
   <actions/>
   <description>Download the version of the Mozmill Environment as specified with the global $MOZMILL_VERSION variable.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>5</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/get_mozmill-tests/config.xml
+++ b/jenkins-master/jobs/get_mozmill-tests/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description></description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/mozilla-aurora_addons/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_addons/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute add-ons tests for Nighly and Aurora builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/mozilla-aurora_endurance/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_endurance/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute endurance tests for Nighly and Aurora builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/mozilla-aurora_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_functional/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute functional tests for Nighly and Aurora builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/mozilla-aurora_l10n/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_l10n/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute functional tests for Nighly and Aurora builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/mozilla-aurora_remote/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_remote/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute remote tests for Nighly and Aurora builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/mozilla-aurora_update/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_update/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute update tests for Nighly and Aurora builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/mozilla-central_addons/config.xml
+++ b/jenkins-master/jobs/mozilla-central_addons/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute add-ons tests for Nighly and Aurora builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/mozilla-central_endurance/config.xml
+++ b/jenkins-master/jobs/mozilla-central_endurance/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute endurance tests for Nighly and Aurora builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/mozilla-central_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-central_functional/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute functional tests for Nighly and Aurora builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/mozilla-central_l10n/config.xml
+++ b/jenkins-master/jobs/mozilla-central_l10n/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute functional tests for Nighly and Aurora builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/mozilla-central_remote/config.xml
+++ b/jenkins-master/jobs/mozilla-central_remote/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute remote tests for Nighly and Aurora builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/mozilla-central_update/config.xml
+++ b/jenkins-master/jobs/mozilla-central_update/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute update tests for Nighly and Aurora builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/mozilla-esr10_addons/config.xml
+++ b/jenkins-master/jobs/mozilla-esr10_addons/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute add-ons tests for Nighly and Aurora builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/mozilla-esr10_endurance/config.xml
+++ b/jenkins-master/jobs/mozilla-esr10_endurance/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute endurance tests for Nighly and Aurora builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/mozilla-esr10_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-esr10_functional/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute functional tests for Nighly and Aurora builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/mozilla-esr10_remote/config.xml
+++ b/jenkins-master/jobs/mozilla-esr10_remote/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute remote tests for Nighly and Aurora builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/mozilla-esr10_update/config.xml
+++ b/jenkins-master/jobs/mozilla-esr10_update/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute update tests for Nighly and Aurora builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/ondemand_addons/config.xml
+++ b/jenkins-master/jobs/ondemand_addons/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute add-ons tests for release and candidate builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/ondemand_endurance/config.xml
+++ b/jenkins-master/jobs/ondemand_endurance/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute endurance tests for release and candidate builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/ondemand_functional/config.xml
+++ b/jenkins-master/jobs/ondemand_functional/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute functional tests for release and candidate builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/ondemand_l10n/config.xml
+++ b/jenkins-master/jobs/ondemand_l10n/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute functional tests for Nighly and Aurora builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/ondemand_remote/config.xml
+++ b/jenkins-master/jobs/ondemand_remote/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute remote tests for release and candidate builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/ondemand_update/config.xml
+++ b/jenkins-master/jobs/ondemand_update/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute update tests for release and candidate builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/release-mozilla-beta_addons/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_addons/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute remote tests for Beta candidate builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/release-mozilla-beta_endurance/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_endurance/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute remote tests for Beta candidate builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/release-mozilla-beta_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_functional/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute remote tests for Beta candidate builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/release-mozilla-beta_remote/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_remote/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute remote tests for Beta candidate builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/release-mozilla-release_addons/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_addons/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute remote tests for Release candidate builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/release-mozilla-release_endurance/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_endurance/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute remote tests for Release candidate builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/release-mozilla-release_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_functional/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute remote tests for Release candidate builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/release-mozilla-release_remote/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_remote/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Execute remote tests for Release candidate builds.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/tools/config.xml
+++ b/jenkins-master/jobs/tools/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Offer platform related tools.</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>5</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>

--- a/jenkins-master/jobs/trigger-ondemand/config.xml
+++ b/jenkins-master/jobs/trigger-ondemand/config.xml
@@ -2,6 +2,12 @@
 <project>
   <actions/>
   <description>Trigger an on-demand test run</description>
+  <logRotator>
+    <daysToKeep>-1</daysToKeep>
+    <numToKeep>100</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
   <keepDependencies>false</keepDependencies>
   <properties>
     <hudson.queueSorter.PrioritySorterJobProperty>


### PR DESCRIPTION
For testruns we keep the last 100 builds and for manually triggered jobs it's enough to have the last 5 builds available.
