### PR TITLE
Revert "Disable testruns for German locale due to bug 851720."

### DIFF
--- a/config/production/daily.json
+++ b/config/production/daily.json
@@ -15,6 +15,7 @@
             "firefox"
         ],
         "locales": [
+            "de",
             "en-US",
             "fr",
             "it"

--- a/config/production/release.json
+++ b/config/production/release.json
@@ -15,6 +15,7 @@
             "firefox"
         ],
         "locales": [
+            "de",
             "en-US",
             "fr",
             "it"

--- a/config/production_new/daily.json
+++ b/config/production_new/daily.json
@@ -16,6 +16,7 @@
             "firefox"
         ],
         "locales": [
+            "de",
             "en-US",
             "fr",
             "it"

--- a/config/production_new/release.json
+++ b/config/production_new/release.json
@@ -16,6 +16,7 @@
             "firefox"
         ],
         "locales": [
+            "de",
             "en-US",
             "fr",
             "it"


### PR DESCRIPTION
The bug with German builds has now been fixed. This addresses issue #222
