### PR TITLE
Fixup linux64 config for staging

### DIFF
--- a/config/staging/daily.json
+++ b/config/staging/daily.json
@@ -84,6 +84,9 @@
                     ],
                     "linux": [
                         "linux && ubuntu && 32bit"
+                    ],
+                    "linux64": [
+                        "linux && ubuntu && 64bit"
                     ]
                 }
             },
@@ -106,7 +109,7 @@
                         "linux && ubuntu && 32bit"
                     ],
                     "linux64": [
-                        "linux && ubuntu && 12.04 && 64bit"
+                        "linux && ubuntu && 64bit"
                     ]
                 }
             },
@@ -127,6 +130,9 @@
                     ],
                     "linux": [
                         "linux && ubuntu && 32bit"
+                    ],
+                    "linux64": [
+                        "linux && ubuntu && 64bit"
                     ]
                 }
             }

--- a/config/staging/release.json
+++ b/config/staging/release.json
@@ -84,6 +84,9 @@
                     ],
                     "linux": [
                         "linux && ubuntu && 32bit"
+                    ],
+                    "linux64": [
+                        "linux && ubuntu && 64bit"
                     ]
                 }
             },
@@ -103,6 +106,9 @@
                     ],
                     "linux": [
                         "linux && ubuntu && 32bit"
+                    ],
+                    "linux64": [
+                        "linux && ubuntu && 64bit"
                     ]
                 }
             },
@@ -122,6 +128,9 @@
                     ],
                     "linux": [
                         "linux && ubuntu && 32bit"
+                    ],
+                    "linux64": [
+                        "linux && ubuntu && 64bit"
                     ]
                 }
             }


### PR DESCRIPTION
@davehunt I just discovered that we do not correctly test on staging and miss the linux64 platform. This patch will fix it.
