### PR TITLE
Use a time trigger as workaround for issue #103 to update get_mozmill-tests

### DIFF
--- a/jenkins-master/jobs/get_mozmill-tests/config.xml
+++ b/jenkins-master/jobs/get_mozmill-tests/config.xml
@@ -30,9 +30,9 @@
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <triggers class="vector">
-    <hudson.triggers.SCMTrigger>
-      <spec>*/15 * * * *</spec>
-    </hudson.triggers.SCMTrigger>
+    <hudson.triggers.TimerTrigger>
+      <spec>*/5 * * * *</spec>
+    </hudson.triggers.TimerTrigger>
   </triggers>
   <concurrentBuild>false</concurrentBuild>
   <builders>


### PR DESCRIPTION
At the same time lets reduce the interval to 5 minutes. It really doesn't harm us.
