### PR TITLE
Disable Ubuntu 12.10 nodes (#261)

### DIFF
--- a/config/ondemand/functional-all.ini
+++ b/config/ondemand/functional-all.ini
@@ -22,14 +22,6 @@ platform=linux
 platform=linux64
 23.0.1=en-US
 
-[linux ubuntu 12.10 32bit]
-platform=linux
-23.0.1=en-US
-
-[linux ubuntu 12.10 64bit]
-platform=linux64
-23.0.1=en-US
-
 [linux ubuntu 13.04 32bit]
 platform=linux
 23.0.1=en-US

--- a/config/production/daily.json
+++ b/config/production/daily.json
@@ -80,12 +80,10 @@
                 "platforms": {
                     "linux": [
                         "linux && ubuntu && 12.04 && 32bit",
-                        "linux && ubuntu && 12.10 && 32bit",
                         "linux && ubuntu && 13.04 && 32bit"
                     ],
                     "linux64": [
                         "linux && ubuntu && 12.04 && 64bit",
-                        "linux && ubuntu && 12.10 && 64bit",
                         "linux && ubuntu && 13.04 && 64bit"
                     ],
                     "mac": [
@@ -114,12 +112,10 @@
                 "platforms": {
                     "linux": [
                         "linux && ubuntu && 12.04 && 32bit",
-                        "linux && ubuntu && 12.10 && 32bit",
                         "linux && ubuntu && 13.04 && 32bit"
                     ],
                     "linux64": [
                         "linux && ubuntu && 12.04 && 64bit",
-                        "linux && ubuntu && 12.10 && 64bit",
                         "linux && ubuntu && 13.04 && 64bit"
                     ],
                     "mac": [
@@ -148,12 +144,10 @@
                 "platforms": {
                     "linux": [
                         "linux && ubuntu && 12.04 && 32bit",
-                        "linux && ubuntu && 12.10 && 32bit",
                         "linux && ubuntu && 13.04 && 32bit"
                     ],
                     "linux64": [
                         "linux && ubuntu && 12.04 && 64bit",
-                        "linux && ubuntu && 12.10 && 64bit",
                         "linux && ubuntu && 13.04 && 64bit"
                     ],
                     "mac": [

--- a/config/production/jenkins.patch
+++ b/config/production/jenkins.patch
@@ -1,8 +1,8 @@
 diff --git a/jenkins-master/config.xml b/jenkins-master/config.xml
-index e3c6f17..59f17d5 100644
+index e3c6f17..b561842 100644
 --- a/jenkins-master/config.xml
 +++ b/jenkins-master/config.xml
-@@ -14,7 +14,1028 @@
+@@ -14,7 +14,908 @@
    <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
    <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
    <clouds/>
@@ -297,126 +297,6 @@ index e3c6f17..59f17d5 100644
 +      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
 +      <launcher class="hudson.slaves.JNLPLauncher"/>
 +      <label>linux ubuntu 12.04 64bit</label>
-+      <nodeProperties>
-+        <ruby-proxy-object>
-+          <ruby-object ruby-class="Jenkins::Slaves::NodePropertyProxy" pluginid="nodeofflinenotification">
-+            <pluginid pluginid="nodeofflinenotification" ruby-class="String">nodeofflinenotification</pluginid>
-+            <object ruby-class="EmailNodeProperty" pluginid="nodeofflinenotification">
-+              <email pluginid="nodeofflinenotification" ruby-class="String">$NOTIFICATION_ADDRESS</email>
-+            </object>
-+          </ruby-object>
-+        </ruby-proxy-object>
-+      </nodeProperties>
-+    </slave>
-+    <slave>
-+      <name>mm-ub-1210-32-1</name>
-+      <description>Ubuntu 12.10 32bit</description>
-+      <remoteFS>jenkins</remoteFS>
-+      <numExecutors>1</numExecutors>
-+      <mode>NORMAL</mode>
-+      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-+      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>linux ubuntu 12.10 32bit endurance</label>
-+      <nodeProperties>
-+        <ruby-proxy-object>
-+          <ruby-object ruby-class="Jenkins::Slaves::NodePropertyProxy" pluginid="nodeofflinenotification">
-+            <pluginid pluginid="nodeofflinenotification" ruby-class="String">nodeofflinenotification</pluginid>
-+            <object ruby-class="EmailNodeProperty" pluginid="nodeofflinenotification">
-+              <email pluginid="nodeofflinenotification" ruby-class="String">$NOTIFICATION_ADDRESS</email>
-+            </object>
-+          </ruby-object>
-+        </ruby-proxy-object>
-+      </nodeProperties>
-+    </slave>
-+    <slave>
-+      <name>mm-ub-1210-32-2</name>
-+      <description>Ubuntu 12.10 32bit</description>
-+      <remoteFS>jenkins</remoteFS>
-+      <numExecutors>1</numExecutors>
-+      <mode>NORMAL</mode>
-+      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-+      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>linux ubuntu 12.10 32bit</label>
-+      <nodeProperties>
-+        <ruby-proxy-object>
-+          <ruby-object ruby-class="Jenkins::Slaves::NodePropertyProxy" pluginid="nodeofflinenotification">
-+            <pluginid pluginid="nodeofflinenotification" ruby-class="String">nodeofflinenotification</pluginid>
-+            <object ruby-class="EmailNodeProperty" pluginid="nodeofflinenotification">
-+              <email pluginid="nodeofflinenotification" ruby-class="String">$NOTIFICATION_ADDRESS</email>
-+            </object>
-+          </ruby-object>
-+        </ruby-proxy-object>
-+      </nodeProperties>
-+    </slave>
-+    <slave>
-+      <name>mm-ub-1210-32-3</name>
-+      <description>Ubuntu 12.10 32bit</description>
-+      <remoteFS>jenkins</remoteFS>
-+      <numExecutors>1</numExecutors>
-+      <mode>NORMAL</mode>
-+      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-+      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>linux ubuntu 12.10 32bit</label>
-+      <nodeProperties>
-+        <ruby-proxy-object>
-+          <ruby-object ruby-class="Jenkins::Slaves::NodePropertyProxy" pluginid="nodeofflinenotification">
-+            <pluginid pluginid="nodeofflinenotification" ruby-class="String">nodeofflinenotification</pluginid>
-+            <object ruby-class="EmailNodeProperty" pluginid="nodeofflinenotification">
-+              <email pluginid="nodeofflinenotification" ruby-class="String">$NOTIFICATION_ADDRESS</email>
-+            </object>
-+          </ruby-object>
-+        </ruby-proxy-object>
-+      </nodeProperties>
-+    </slave>
-+    <slave>
-+      <name>mm-ub-1210-64-1</name>
-+      <description>Ubuntu 12.10 64bit</description>
-+      <remoteFS>jenkins</remoteFS>
-+      <numExecutors>1</numExecutors>
-+      <mode>NORMAL</mode>
-+      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-+      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>linux ubuntu 12.10 64bit endurance</label>
-+      <nodeProperties>
-+        <ruby-proxy-object>
-+          <ruby-object ruby-class="Jenkins::Slaves::NodePropertyProxy" pluginid="nodeofflinenotification">
-+            <pluginid pluginid="nodeofflinenotification" ruby-class="String">nodeofflinenotification</pluginid>
-+            <object ruby-class="EmailNodeProperty" pluginid="nodeofflinenotification">
-+              <email pluginid="nodeofflinenotification" ruby-class="String">$NOTIFICATION_ADDRESS</email>
-+            </object>
-+          </ruby-object>
-+        </ruby-proxy-object>
-+      </nodeProperties>
-+    </slave>
-+    <slave>
-+      <name>mm-ub-1210-64-2</name>
-+      <description>Ubuntu 12.10 64bit</description>
-+      <remoteFS>jenkins</remoteFS>
-+      <numExecutors>1</numExecutors>
-+      <mode>NORMAL</mode>
-+      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-+      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>linux ubuntu 12.10 64bit</label>
-+      <nodeProperties>
-+        <ruby-proxy-object>
-+          <ruby-object ruby-class="Jenkins::Slaves::NodePropertyProxy" pluginid="nodeofflinenotification">
-+            <pluginid pluginid="nodeofflinenotification" ruby-class="String">nodeofflinenotification</pluginid>
-+            <object ruby-class="EmailNodeProperty" pluginid="nodeofflinenotification">
-+              <email pluginid="nodeofflinenotification" ruby-class="String">$NOTIFICATION_ADDRESS</email>
-+            </object>
-+          </ruby-object>
-+        </ruby-proxy-object>
-+      </nodeProperties>
-+    </slave>
-+    <slave>
-+      <name>mm-ub-1210-64-3</name>
-+      <description>Ubuntu 12.10 64bit</description>
-+      <remoteFS>jenkins</remoteFS>
-+      <numExecutors>1</numExecutors>
-+      <mode>NORMAL</mode>
-+      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-+      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>linux ubuntu 12.10 64bit</label>
 +      <nodeProperties>
 +        <ruby-proxy-object>
 +          <ruby-object ruby-class="Jenkins::Slaves::NodePropertyProxy" pluginid="nodeofflinenotification">
@@ -1032,7 +912,7 @@ index e3c6f17..59f17d5 100644
    <quietPeriod>5</quietPeriod>
    <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
    <views>
-@@ -203,7 +1224,7 @@
+@@ -203,7 +1104,7 @@
            <string>MOZMILL_VERSION</string>
            <string>1.5.21</string>
            <string>NOTIFICATION_ADDRESS</string>

--- a/config/production/l10n.json
+++ b/config/production/l10n.json
@@ -53,7 +53,7 @@
                 ],
                 "platforms": {
                     "linux": [
-                        "linux && ubuntu && 12.10 && 32bit"
+                        "linux && ubuntu && 12.04 && 32bit"
                     ],
                     "mac": [
                         "mac && 10.7 && 64bit"

--- a/config/production/release.json
+++ b/config/production/release.json
@@ -81,12 +81,10 @@
                 "platforms": {
                     "linux": [
                         "linux && ubuntu && 12.04 && 32bit",
-                        "linux && ubuntu && 12.10 && 32bit",
                         "linux && ubuntu && 13.04 && 32bit"
                     ],
                     "linux64": [
                         "linux && ubuntu && 12.04 && 64bit",
-                        "linux && ubuntu && 12.10 && 64bit",
                         "linux && ubuntu && 13.04 && 64bit"
                     ],
                     "mac": [
@@ -114,12 +112,10 @@
                 "platforms": {
                     "linux": [
                         "linux && ubuntu && 12.04 && 32bit",
-                        "linux && ubuntu && 12.10 && 32bit",
                         "linux && ubuntu && 13.04 && 32bit"
                     ],
                     "linux64": [
                         "linux && ubuntu && 12.04 && 64bit",
-                        "linux && ubuntu && 12.10 && 64bit",
                         "linux && ubuntu && 13.04 && 64bit"
                     ],
                     "mac": [
@@ -147,12 +143,10 @@
                 "platforms": {
                     "linux": [
                         "linux && ubuntu && 12.04 && 32bit",
-                        "linux && ubuntu && 12.10 && 32bit",
                         "linux && ubuntu && 13.04 && 32bit"
                     ],
                     "linux64": [
                         "linux && ubuntu && 12.04 && 64bit",
-                        "linux && ubuntu && 12.10 && 64bit",
                         "linux && ubuntu && 13.04 && 64bit"
                     ],
                     "mac": [


### PR DESCRIPTION
I already upload this patch so we can review it in-front. As mentioned on the issue, I will shutdown 12.10 machines earliest on Monday if all goes well with 13.04.
