### PR TITLE
Use comma as separator for artifacts (#304)

### DIFF
--- a/jenkins-master/jobs/mozilla-aurora_update/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_update/config.xml
@@ -116,7 +116,7 @@
   </builders>
   <publishers>
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>screenshots/ http.log</artifacts>
+      <artifacts>screenshots/,http.log</artifacts>
       <latestOnly>false</latestOnly>
       <allowEmptyArchive>false</allowEmptyArchive>
     </hudson.tasks.ArtifactArchiver>

--- a/jenkins-master/jobs/mozilla-central_update/config.xml
+++ b/jenkins-master/jobs/mozilla-central_update/config.xml
@@ -116,7 +116,7 @@
   </builders>
   <publishers>
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>screenshots/ http.log</artifacts>
+      <artifacts>screenshots/,http.log</artifacts>
       <latestOnly>false</latestOnly>
       <allowEmptyArchive>false</allowEmptyArchive>
     </hudson.tasks.ArtifactArchiver>

--- a/jenkins-master/jobs/mozilla-esr17_update/config.xml
+++ b/jenkins-master/jobs/mozilla-esr17_update/config.xml
@@ -116,7 +116,7 @@
   </builders>
   <publishers>
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>screenshots/ http.log</artifacts>
+      <artifacts>screenshots/,http.log</artifacts>
       <latestOnly>false</latestOnly>
       <allowEmptyArchive>false</allowEmptyArchive>
     </hudson.tasks.ArtifactArchiver>

--- a/jenkins-master/jobs/mozilla-esr24_update/config.xml
+++ b/jenkins-master/jobs/mozilla-esr24_update/config.xml
@@ -116,7 +116,7 @@
   </builders>
   <publishers>
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>screenshots/ http.log</artifacts>
+      <artifacts>screenshots/,http.log</artifacts>
       <latestOnly>false</latestOnly>
       <allowEmptyArchive>false</allowEmptyArchive>
     </hudson.tasks.ArtifactArchiver>

--- a/jenkins-master/jobs/ondemand_update/config.xml
+++ b/jenkins-master/jobs/ondemand_update/config.xml
@@ -128,7 +128,7 @@
   </builders>
   <publishers>
     <hudson.tasks.ArtifactArchiver>
-      <artifacts>screenshots/ http.log</artifacts>
+      <artifacts>screenshots/,http.log</artifacts>
       <latestOnly>false</latestOnly>
       <allowEmptyArchive>false</allowEmptyArchive>
     </hudson.tasks.ArtifactArchiver>


### PR DESCRIPTION
@davehunt mind having a look at? Quick fix necessary given that the current documentation is not up-to-date anymore and doesn't allow a blank as separator.
