### PR TITLE
Disable daily tests on Win8.1 for esr builds too (#307)

### DIFF
--- a/config/production/daily.json
+++ b/config/production/daily.json
@@ -162,9 +162,7 @@
                         "windows && 7 && 32bit",
                         "windows && 7 && 64bit",
                         "windows && 8 && 32bit",
-                        "windows && 8 && 64bit",
-                        "windows && 8.1 && 32bit",
-                        "windows && 8.1 && 64bit"
+                        "windows && 8 && 64bit"
                     ]
                 }
             },

--- a/config/production/release.json
+++ b/config/production/release.json
@@ -197,9 +197,7 @@
                         "windows && 7 && 32bit",
                         "windows && 7 && 64bit",
                         "windows && 8 && 32bit",
-                        "windows && 8 && 64bit",
-                        "windows && 8.1 && 32bit",
-                        "windows && 8.1 && 64bit"
+                        "windows && 8 && 64bit"
                     ]
                 }
             }


### PR DESCRIPTION
@davehunt, can you please have a look? I'm sorry that I missed that with the backout. Looks like we should not revert patches after a long time to not risk regressions like those.
