### PR TITLE
Enable OS X 10.9 machines for testing (#321)

### DIFF
--- a/config/production/daily.json
+++ b/config/production/daily.json
@@ -90,7 +90,8 @@
                     "mac": [
                         "mac && 10.6 && 64bit",
                         "mac && 10.7 && 64bit",
-                        "mac && 10.8 && 64bit"
+                        "mac && 10.8 && 64bit",
+                        "mac && 10.9 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -122,7 +123,8 @@
                     "mac": [
                         "mac && 10.6 && 64bit",
                         "mac && 10.7 && 64bit",
-                        "mac && 10.8 && 64bit"
+                        "mac && 10.8 && 64bit",
+                        "mac && 10.9 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -154,7 +156,8 @@
                     "mac": [
                         "mac && 10.6 && 64bit",
                         "mac && 10.7 && 64bit",
-                        "mac && 10.8 && 64bit"
+                        "mac && 10.8 && 64bit",
+                        "mac && 10.9 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -186,7 +189,8 @@
                     "mac": [
                         "mac && 10.6 && 64bit",
                         "mac && 10.7 && 64bit",
-                        "mac && 10.8 && 64bit"
+                        "mac && 10.8 && 64bit",
+                        "mac && 10.9 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",

--- a/config/production/release.json
+++ b/config/production/release.json
@@ -97,7 +97,8 @@
                     "mac": [
                         "mac && 10.6 && 64bit",
                         "mac && 10.7 && 64bit",
-                        "mac && 10.8 && 64bit"
+                        "mac && 10.8 && 64bit",
+                        "mac && 10.9 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -136,7 +137,8 @@
                         "windows && 7 && 32bit",
                         "windows && 7 && 64bit",
                         "windows && 8 && 32bit",
-                        "windows && 8 && 64bit"
+                        "windows && 8 && 64bit",
+                        "mac && 10.9 && 64bit"
                     ]
                 }
             },
@@ -159,7 +161,8 @@
                     "mac": [
                         "mac && 10.6 && 64bit",
                         "mac && 10.7 && 64bit",
-                        "mac && 10.8 && 64bit"
+                        "mac && 10.8 && 64bit",
+                        "mac && 10.9 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -189,7 +192,8 @@
                     "mac": [
                         "mac && 10.6 && 64bit",
                         "mac && 10.7 && 64bit",
-                        "mac && 10.8 && 64bit"
+                        "mac && 10.8 && 64bit",
+                        "mac && 10.9 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",


### PR DESCRIPTION
@davehunt I think that should be all to let our tests running on 10.9.
