### PR TITLE
Provide default values for regex matches in email notifications (#266)

### DIFF
--- a/jenkins-master/jobs/mozilla-aurora_addons/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_addons/config.xml
@@ -142,7 +142,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -175,8 +175,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-aurora_endurance/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_endurance/config.xml
@@ -157,7 +157,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -190,8 +190,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-aurora_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_functional/config.xml
@@ -142,7 +142,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -175,8 +175,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-aurora_l10n/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_l10n/config.xml
@@ -142,7 +142,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -175,8 +175,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-aurora_remote/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_remote/config.xml
@@ -142,7 +142,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -175,8 +175,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-aurora_update/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_update/config.xml
@@ -152,7 +152,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -185,8 +185,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-central_addons/config.xml
+++ b/jenkins-master/jobs/mozilla-central_addons/config.xml
@@ -147,7 +147,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -180,8 +180,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-central_endurance/config.xml
+++ b/jenkins-master/jobs/mozilla-central_endurance/config.xml
@@ -157,7 +157,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -190,8 +190,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-central_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-central_functional/config.xml
@@ -142,7 +142,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -175,8 +175,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-central_remote/config.xml
+++ b/jenkins-master/jobs/mozilla-central_remote/config.xml
@@ -142,7 +142,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -175,8 +175,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-central_update/config.xml
+++ b/jenkins-master/jobs/mozilla-central_update/config.xml
@@ -152,7 +152,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -185,8 +185,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-esr17_addons/config.xml
+++ b/jenkins-master/jobs/mozilla-esr17_addons/config.xml
@@ -142,7 +142,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -175,8 +175,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-esr17_endurance/config.xml
+++ b/jenkins-master/jobs/mozilla-esr17_endurance/config.xml
@@ -157,7 +157,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -190,8 +190,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-esr17_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-esr17_functional/config.xml
@@ -142,7 +142,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -175,8 +175,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-esr17_remote/config.xml
+++ b/jenkins-master/jobs/mozilla-esr17_remote/config.xml
@@ -142,7 +142,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -175,8 +175,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-esr17_update/config.xml
+++ b/jenkins-master/jobs/mozilla-esr17_update/config.xml
@@ -152,7 +152,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -185,8 +185,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-esr24_addons/config.xml
+++ b/jenkins-master/jobs/mozilla-esr24_addons/config.xml
@@ -142,7 +142,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -175,8 +175,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-esr24_endurance/config.xml
+++ b/jenkins-master/jobs/mozilla-esr24_endurance/config.xml
@@ -157,7 +157,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -190,8 +190,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-esr24_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-esr24_functional/config.xml
@@ -142,7 +142,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -175,8 +175,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-esr24_remote/config.xml
+++ b/jenkins-master/jobs/mozilla-esr24_remote/config.xml
@@ -142,7 +142,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -175,8 +175,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-esr24_update/config.xml
+++ b/jenkins-master/jobs/mozilla-esr24_update/config.xml
@@ -152,7 +152,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -185,8 +185,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/ondemand_addons/config.xml
+++ b/jenkins-master/jobs/ondemand_addons/config.xml
@@ -142,7 +142,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -175,8 +175,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/ondemand_endurance/config.xml
+++ b/jenkins-master/jobs/ondemand_endurance/config.xml
@@ -157,7 +157,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -190,8 +190,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/ondemand_functional/config.xml
+++ b/jenkins-master/jobs/ondemand_functional/config.xml
@@ -142,7 +142,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -175,8 +175,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/ondemand_l10n/config.xml
+++ b/jenkins-master/jobs/ondemand_l10n/config.xml
@@ -148,7 +148,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -181,8 +181,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/ondemand_remote/config.xml
+++ b/jenkins-master/jobs/ondemand_remote/config.xml
@@ -142,7 +142,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -175,8 +175,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/ondemand_update/config.xml
+++ b/jenkins-master/jobs/ondemand_update/config.xml
@@ -152,7 +152,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -185,8 +185,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/project_addons/config.xml
+++ b/jenkins-master/jobs/project_addons/config.xml
@@ -152,7 +152,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -185,8 +185,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/project_endurance/config.xml
+++ b/jenkins-master/jobs/project_endurance/config.xml
@@ -162,7 +162,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -195,8 +195,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/project_functional/config.xml
+++ b/jenkins-master/jobs/project_functional/config.xml
@@ -147,7 +147,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -180,8 +180,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/project_remote/config.xml
+++ b/jenkins-master/jobs/project_remote/config.xml
@@ -147,7 +147,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -180,8 +180,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/project_update/config.xml
+++ b/jenkins-master/jobs/project_update/config.xml
@@ -152,7 +152,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -185,8 +185,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-beta_addons/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_addons/config.xml
@@ -137,7 +137,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -170,8 +170,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-beta_endurance/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_endurance/config.xml
@@ -152,7 +152,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -185,8 +185,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-beta_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_functional/config.xml
@@ -137,7 +137,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -170,8 +170,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-beta_remote/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_remote/config.xml
@@ -137,7 +137,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -170,8 +170,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-esr17_addons/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr17_addons/config.xml
@@ -137,7 +137,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -170,8 +170,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-esr17_endurance/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr17_endurance/config.xml
@@ -152,7 +152,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -185,8 +185,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-esr17_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr17_functional/config.xml
@@ -137,7 +137,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -170,8 +170,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-esr17_remote/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr17_remote/config.xml
@@ -137,7 +137,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -170,8 +170,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-esr24_addons/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr24_addons/config.xml
@@ -137,7 +137,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -170,8 +170,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-esr24_endurance/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr24_endurance/config.xml
@@ -152,7 +152,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -185,8 +185,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-esr24_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr24_functional/config.xml
@@ -137,7 +137,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -170,8 +170,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-esr24_remote/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr24_remote/config.xml
@@ -137,7 +137,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -170,8 +170,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-release_addons/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_addons/config.xml
@@ -137,7 +137,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -170,8 +170,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-release_endurance/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_endurance/config.xml
@@ -152,7 +152,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -185,8 +185,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-release_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_functional/config.xml
@@ -137,7 +137,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -170,8 +170,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-release_remote/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_remote/config.xml
@@ -137,7 +137,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
+            <body>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -170,8 +170,8 @@ ${BUILD_URL}</body>
         </hudson.plugins.emailext.plugins.trigger.FailureTrigger>
       </configuredTriggers>
       <contentType>default</contentType>
-      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
-      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;[application]&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME}: ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;})</defaultSubject>
+      <defaultContent>Mozmill ${PROJECT_NAME} testrun for ${BUILD_LOG_REGEX, regex=&quot;^\\*{3} Application: (.*) \\(.*\\)$&quot;, maxMatches=1, showTruncatedLines=false, substText=&quot;$1&quot;, addNewline=false, defaultValue=&quot;%application%&quot;} ${ENV,var=&quot;LOCALE&quot;} on ${NODE_NAME} (${ENV,var=&quot;BUILD_ID&quot;}) completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}


### PR DESCRIPTION
This will make the e-mail notifications contain '[application]' when the full application details cannot be extracted from the console log. See below for an example.

Before:

> Subject: [Aborted] mozilla-central_remote:  en-US on master (20131128030201)
> Mozmill mozilla-central_remote testrun for  en-US on master (20131128030201) was aborted.

After:

> Subject: [Aborted] mozilla-central_remote: [application] en-US on master (20131128030201)
> Mozmill mozilla-central_remote testrun for [application] en-US on master (20131128030201) was aborted.

I'm open to suggestions for any alternatives to '[application]'
