### PR TITLE
Pulse triggered release tests are broken due to project branch feature (#396)

### DIFF
--- a/pulse.py
+++ b/pulse.py
@@ -194,7 +194,7 @@ class Automation:
 
         # If it is not an official nightly or release branch, assume a project
         # branch based off from mozilla-central
-        if not data['tree'].startswith('mozilla-'):
+        if not 'mozilla-' in data['tree']:
             data['branch'] = data['tree']
             data['tree'] = 'project'
 


### PR DESCRIPTION
Quick fix for issue #396 to re-enable the automatic job generation from pulse for release builds. We might want to have some more automation for such kind of issues in the future. I will do another pull later.
