### PR TITLE
Add APPLICATION parameter to all jobs

### DIFF
--- a/config/production/daily.json
+++ b/config/production/daily.json
@@ -34,6 +34,9 @@
     "testrun": {
         "jenkins_parameter_map": {
             "default": {
+                "APPLICATION": {
+                    "key": "product"
+                },
                 "BRANCH": {
                     "key": "branch"
                 },

--- a/config/production/l10n.json
+++ b/config/production/l10n.json
@@ -28,6 +28,9 @@
     "testrun": {
         "jenkins_parameter_map": {
             "default": {
+                "APPLICATION": {
+                    "key": "product"
+                },
                 "BRANCH": {
                     "key": "branch"
                 },

--- a/config/production/release.json
+++ b/config/production/release.json
@@ -39,6 +39,9 @@
     "testrun": {
         "jenkins_parameter_map": {
             "default": {
+                "APPLICATION": {
+                    "key": "product"
+                },
                 "BRANCH": {
                     "key": "branch"
                 },

--- a/config/staging/daily.json
+++ b/config/staging/daily.json
@@ -32,6 +32,9 @@
     "testrun": {
         "jenkins_parameter_map": {
             "default": {
+                "APPLICATION": {
+                    "key": "product"
+                },
                 "BRANCH": {
                     "key": "branch"
                 },

--- a/config/staging/l10n.json
+++ b/config/staging/l10n.json
@@ -32,6 +32,9 @@
     "testrun": {
         "jenkins_parameter_map": {
             "default": {
+                "APPLICATION": {
+                    "key": "product"
+                },
                 "BRANCH": {
                     "key": "branch"
                 },

--- a/config/staging/release.json
+++ b/config/staging/release.json
@@ -30,6 +30,9 @@
     "testrun": {
         "jenkins_parameter_map": {
             "default": {
+                "APPLICATION": {
+                    "key": "product"
+                },
                 "BRANCH": {
                     "key": "branch"
                 },

--- a/jenkins-master/jobs/mozilla-aurora_addons/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_addons/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_ID</name>
           <description>The build id of Firefox.</description>
           <defaultValue></defaultValue>
@@ -102,7 +107,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_addons --with-untrusted --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_addons --app=$APPLICATION --with-untrusted --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/mozilla-aurora_endurance/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_endurance/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_ID</name>
           <description>The build id of Firefox.</description>
           <defaultValue></defaultValue>
@@ -117,7 +122,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_endurance --iterations=$ITERATIONS --entities=$ENTITIES --delay=$DELAY --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_endurance  --app=$APPLICATION --iterations=$ITERATIONS --entities=$ENTITIES --delay=$DELAY --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/mozilla-aurora_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_functional/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_ID</name>
           <description>The build id of Firefox.</description>
           <defaultValue></defaultValue>
@@ -102,7 +107,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_functional --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_functional --app=$APPLICATION --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/mozilla-aurora_l10n/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_l10n/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_ID</name>
           <description>The build id of Firefox.</description>
           <defaultValue></defaultValue>
@@ -102,7 +107,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_l10n --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_l10n --app=$APPLICATION --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/mozilla-aurora_remote/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_remote/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_ID</name>
           <description>The build id of Firefox.</description>
           <defaultValue></defaultValue>
@@ -102,7 +107,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_remote --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_remote --app=$APPLICATION --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/mozilla-aurora_update/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_update/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_ID</name>
           <description>The build id of Firefox.</description>
           <defaultValue></defaultValue>
@@ -112,7 +117,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_update --channel=$CHANNEL --target-buildid=$TARGET_BUILD_ID --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_update --app=$APPLICATION --channel=$CHANNEL --target-buildid=$TARGET_BUILD_ID --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/mozilla-central_addons/config.xml
+++ b/jenkins-master/jobs/mozilla-central_addons/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_ID</name>
           <description>The build id of Firefox.</description>
           <defaultValue></defaultValue>
@@ -102,7 +107,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_addons --with-untrusted --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_addons --app=$APPLICATION --with-untrusted --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/mozilla-central_endurance/config.xml
+++ b/jenkins-master/jobs/mozilla-central_endurance/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_ID</name>
           <description>The build id of Firefox.</description>
           <defaultValue></defaultValue>
@@ -117,7 +122,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_endurance --iterations=$ITERATIONS --entities=$ENTITIES --delay=$DELAY --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_endurance --app=$APPLICATION --iterations=$ITERATIONS --entities=$ENTITIES --delay=$DELAY --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/mozilla-central_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-central_functional/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_ID</name>
           <description>The build id of Firefox.</description>
           <defaultValue></defaultValue>
@@ -102,7 +107,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_functional --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_functional --app=$APPLICATION --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/mozilla-central_remote/config.xml
+++ b/jenkins-master/jobs/mozilla-central_remote/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_ID</name>
           <description>The build id of Firefox.</description>
           <defaultValue></defaultValue>
@@ -102,7 +107,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_remote --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_remote --app=$APPLICATION --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/mozilla-central_update/config.xml
+++ b/jenkins-master/jobs/mozilla-central_update/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_ID</name>
           <description>The build id of Firefox.</description>
           <defaultValue></defaultValue>
@@ -112,7 +117,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_update --channel=$CHANNEL --target-buildid=$TARGET_BUILD_ID --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_update --app=$APPLICATION --channel=$CHANNEL --target-buildid=$TARGET_BUILD_ID --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/mozilla-esr24_addons/config.xml
+++ b/jenkins-master/jobs/mozilla-esr24_addons/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_ID</name>
           <description>The build id of Firefox.</description>
           <defaultValue></defaultValue>
@@ -102,7 +107,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_addons --with-untrusted --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_addons --app=$APPLICATION --with-untrusted --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/mozilla-esr24_endurance/config.xml
+++ b/jenkins-master/jobs/mozilla-esr24_endurance/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_ID</name>
           <description>The build id of Firefox.</description>
           <defaultValue></defaultValue>
@@ -117,7 +122,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_endurance --iterations=$ITERATIONS --entities=$ENTITIES --delay=$DELAY --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_endurance --app=$APPLICATION --iterations=$ITERATIONS --entities=$ENTITIES --delay=$DELAY --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/mozilla-esr24_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-esr24_functional/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_ID</name>
           <description>The build id of Firefox.</description>
           <defaultValue></defaultValue>
@@ -102,7 +107,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_functional --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_functional --app=$APPLICATION --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/mozilla-esr24_remote/config.xml
+++ b/jenkins-master/jobs/mozilla-esr24_remote/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_ID</name>
           <description>The build id of Firefox.</description>
           <defaultValue></defaultValue>
@@ -102,7 +107,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_remote --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_remote --app=$APPLICATION --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/mozilla-esr24_update/config.xml
+++ b/jenkins-master/jobs/mozilla-esr24_update/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_ID</name>
           <description>The build id of Firefox.</description>
           <defaultValue></defaultValue>
@@ -112,7 +117,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_update --channel=$CHANNEL --target-buildid=$TARGET_BUILD_ID --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_update --app=$APPLICATION --channel=$CHANNEL --target-buildid=$TARGET_BUILD_ID --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/ondemand_addons/config.xml
+++ b/jenkins-master/jobs/ondemand_addons/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_NUMBER</name>
           <description>The build number of Firefox.</description>
           <defaultValue>1</defaultValue>
@@ -102,7 +107,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_addons --with-untrusted --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_addons --app=$APPLICATION --with-untrusted --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/ondemand_endurance/config.xml
+++ b/jenkins-master/jobs/ondemand_endurance/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_NUMBER</name>
           <description>The build number of Firefox.</description>
           <defaultValue>1</defaultValue>
@@ -117,7 +122,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_endurance --iterations=$ITERATIONS --entities=$ENTITIES --delay=$DELAY --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_endurance --app=$APPLICATION --iterations=$ITERATIONS --entities=$ENTITIES --delay=$DELAY --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/ondemand_functional/config.xml
+++ b/jenkins-master/jobs/ondemand_functional/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_NUMBER</name>
           <description>The build number of Firefox.</description>
           <defaultValue>1</defaultValue>
@@ -102,7 +107,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_functional --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_functional --app=$APPLICATION --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/ondemand_l10n/config.xml
+++ b/jenkins-master/jobs/ondemand_l10n/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_NUMBER</name>
           <description>The build number of Firefox.</description>
           <defaultValue>1</defaultValue>
@@ -102,7 +107,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_l10n --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_l10n --app=$APPLICATION --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/ondemand_remote/config.xml
+++ b/jenkins-master/jobs/ondemand_remote/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_NUMBER</name>
           <description>The build number of Firefox.</description>
           <defaultValue>1</defaultValue>
@@ -102,7 +107,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_remote --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_remote --app=$APPLICATION --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/ondemand_update/config.xml
+++ b/jenkins-master/jobs/ondemand_update/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_NUMBER</name>
           <description>The build number of Firefox.</description>
           <defaultValue>1</defaultValue>
@@ -112,7 +117,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_update --target-buildid=$TARGET_BUILD_ID --channel=$CHANNEL --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_update --app=$APPLICATION --target-buildid=$TARGET_BUILD_ID --channel=$CHANNEL --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/project_addons/config.xml
+++ b/jenkins-master/jobs/project_addons/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BRANCH</name>
           <description>The project branch of Firefox.</description>
           <defaultValue></defaultValue>
@@ -107,7 +112,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_addons --with-untrusted --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_addons --app=$APPLICATION --with-untrusted --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/project_endurance/config.xml
+++ b/jenkins-master/jobs/project_endurance/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BRANCH</name>
           <description>The project branch of Firefox.</description>
           <defaultValue></defaultValue>
@@ -122,7 +127,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_endurance --iterations=$ITERATIONS --entities=$ENTITIES --delay=$DELAY --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_endurance --app=$APPLICATION --iterations=$ITERATIONS --entities=$ENTITIES --delay=$DELAY --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/project_functional/config.xml
+++ b/jenkins-master/jobs/project_functional/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BRANCH</name>
           <description>The project branch of Firefox.</description>
           <defaultValue></defaultValue>
@@ -107,7 +112,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_functional --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_functional --app=$APPLICATION --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/project_remote/config.xml
+++ b/jenkins-master/jobs/project_remote/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BRANCH</name>
           <description>The project branch of Firefox.</description>
           <defaultValue></defaultValue>
@@ -107,7 +112,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_remote --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_remote --app=$APPLICATION --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/project_update/config.xml
+++ b/jenkins-master/jobs/project_update/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BRANCH</name>
           <description>The project branch of Firefox.</description>
           <defaultValue></defaultValue>
@@ -112,7 +117,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_update --target-buildid=$TARGET_BUILD_ID --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_update --app=$APPLICATION --target-buildid=$TARGET_BUILD_ID --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/release-mozilla-beta_addons/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_addons/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_NUMBER</name>
           <description>The build number of the Firefox candidate build.</description>
           <defaultValue></defaultValue>
@@ -97,7 +102,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_addons --with-untrusted --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_addons --app=$APPLICATION --with-untrusted --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/release-mozilla-beta_endurance/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_endurance/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_NUMBER</name>
           <description>The build number of the Firefox candidate build.</description>
           <defaultValue></defaultValue>
@@ -112,7 +117,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_endurance --iterations=$ITERATIONS --entities=$ENTITIES --delay=$DELAY --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_endurance --app=$APPLICATION --iterations=$ITERATIONS --entities=$ENTITIES --delay=$DELAY --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/release-mozilla-beta_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_functional/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_NUMBER</name>
           <description>The build number of the Firefox candidate build.</description>
           <defaultValue></defaultValue>
@@ -97,7 +102,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_functional --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_functional --app=$APPLICATION --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/release-mozilla-beta_remote/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_remote/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_NUMBER</name>
           <description>The build number of the Firefox candidate build.</description>
           <defaultValue></defaultValue>
@@ -97,7 +102,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_remote --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_remote --app=$APPLICATION --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/release-mozilla-esr24_addons/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr24_addons/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_NUMBER</name>
           <description>The build number of the Firefox candidate build.</description>
           <defaultValue></defaultValue>
@@ -97,7 +102,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_addons --with-untrusted --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_addons --app=$APPLICATION --with-untrusted --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/release-mozilla-esr24_endurance/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr24_endurance/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_NUMBER</name>
           <description>The build number of the Firefox candidate build.</description>
           <defaultValue></defaultValue>
@@ -112,7 +117,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_endurance --iterations=$ITERATIONS --entities=$ENTITIES --delay=$DELAY --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_endurance --app=$APPLICATION --iterations=$ITERATIONS --entities=$ENTITIES --delay=$DELAY --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/release-mozilla-esr24_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr24_functional/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_NUMBER</name>
           <description>The build number of the Firefox candidate build.</description>
           <defaultValue></defaultValue>
@@ -97,7 +102,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_functional --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_functional --app=$APPLICATION --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/release-mozilla-esr24_remote/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr24_remote/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_NUMBER</name>
           <description>The build number of the Firefox candidate build.</description>
           <defaultValue></defaultValue>
@@ -97,7 +102,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_remote --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_remote --app=$APPLICATION --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/release-mozilla-release_addons/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_addons/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_NUMBER</name>
           <description>The build number of the Firefox candidate build.</description>
           <defaultValue></defaultValue>
@@ -97,7 +102,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_addons --with-untrusted --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_addons --app=$APPLICATION --with-untrusted --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/release-mozilla-release_endurance/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_endurance/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_NUMBER</name>
           <description>The build number of the Firefox candidate build.</description>
           <defaultValue></defaultValue>
@@ -112,7 +117,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_endurance --iterations=$ITERATIONS --entities=$ENTITIES --delay=$DELAY --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_endurance --app=$APPLICATION --iterations=$ITERATIONS --entities=$ENTITIES --delay=$DELAY --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/release-mozilla-release_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_functional/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_NUMBER</name>
           <description>The build number of the Firefox candidate build.</description>
           <defaultValue></defaultValue>
@@ -97,7 +102,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_functional --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_functional --app=$APPLICATION --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>

--- a/jenkins-master/jobs/release-mozilla-release_remote/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_remote/config.xml
@@ -16,6 +16,11 @@
     <hudson.model.ParametersDefinitionProperty>
       <parameterDefinitions>
         <hudson.model.StringParameterDefinition>
+          <name>APPLICATION</name>
+          <description>The application type.</description>
+          <defaultValue>firefox</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>BUILD_NUMBER</name>
           <description>The build number of the Firefox candidate build.</description>
           <defaultValue></defaultValue>
@@ -97,7 +102,7 @@
       <timeAllocated></timeAllocated>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9">
-      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_remote --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
+      <commandLine>mozmill-env-$ENV_PLATFORM/run testrun_remote --app=$APPLICATION --repository=mozmill-tests --junit=report.xml --workspace=data --report=$REPORT_URL builds/</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
       <regexToKill></regexToKill>
       <timeAllocated></timeAllocated>


### PR DESCRIPTION
This adds the app parameter to functional and remote for nightly so far and triggers 2 jobs when we have Win 8.1, one for firefox and one for metrofirefox.
Since we didn't backported the library so far, I figured we don't want changes to aurora/beta just yet.
I've used Cosmin's patch.
