### PR TITLE
Change the maximum number of keept jobs to 10 for staging instance (#416)

### DIFF
--- a/config/production/jenkins.patch
+++ b/config/production/jenkins.patch
@@ -1,5 +1,5 @@
 diff --git a/jenkins-master/config.xml b/jenkins-master/config.xml
-index 5efb66c..2b9bd1c 100644
+index ab7e34c..e1e42c6 100644
 --- a/jenkins-master/config.xml
 +++ b/jenkins-master/config.xml
 @@ -16,16 +16,1028 @@
@@ -1053,7 +1053,7 @@ index 5efb66c..2b9bd1c 100644
        <envVars serialization="custom">
 @@ -248,7 +1265,7 @@
            <string>MOZMILL_AUTOMATION_VERSION</string>
-           <string>2.0.3</string>
+           <string>2.0.5</string>
            <string>NOTIFICATION_ADDRESS</string>
 -          <string></string>
 +          <string>mozmill-ci@mozilla.org</string>
@@ -1096,3 +1096,531 @@ index 2cec9ac..cfce914 100644
 +  <jenkinsUrl>http://mm-ci-master.qa.scl3.mozilla.com:8080/</jenkinsUrl>
  </jenkins.model.JenkinsLocationConfiguration>
 \ No newline at end of file
+diff --git a/jenkins-master/jobs/get_mozmill-tests/config.xml b/jenkins-master/jobs/get_mozmill-tests/config.xml
+index 179daff..9e6e0ff 100644
+--- a/jenkins-master/jobs/get_mozmill-tests/config.xml
++++ b/jenkins-master/jobs/get_mozmill-tests/config.xml
+@@ -4,7 +4,7 @@
+   <description>Clone the Mozmill tests repository.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/mozilla-aurora_addons/config.xml b/jenkins-master/jobs/mozilla-aurora_addons/config.xml
+index f9ec48e..a33b654 100644
+--- a/jenkins-master/jobs/mozilla-aurora_addons/config.xml
++++ b/jenkins-master/jobs/mozilla-aurora_addons/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute add-ons tests for Aurora builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/mozilla-aurora_endurance/config.xml b/jenkins-master/jobs/mozilla-aurora_endurance/config.xml
+index 8d80fea..0463095 100644
+--- a/jenkins-master/jobs/mozilla-aurora_endurance/config.xml
++++ b/jenkins-master/jobs/mozilla-aurora_endurance/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute endurance tests for Aurora builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/mozilla-aurora_functional/config.xml b/jenkins-master/jobs/mozilla-aurora_functional/config.xml
+index f882bef..175d5aa 100644
+--- a/jenkins-master/jobs/mozilla-aurora_functional/config.xml
++++ b/jenkins-master/jobs/mozilla-aurora_functional/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute functional tests for Aurora builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/mozilla-aurora_l10n/config.xml b/jenkins-master/jobs/mozilla-aurora_l10n/config.xml
+index 38481cd..8eee4df 100644
+--- a/jenkins-master/jobs/mozilla-aurora_l10n/config.xml
++++ b/jenkins-master/jobs/mozilla-aurora_l10n/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute l10n tests for Aurora builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/mozilla-aurora_remote/config.xml b/jenkins-master/jobs/mozilla-aurora_remote/config.xml
+index 2c4b9a4..fcc2f56 100644
+--- a/jenkins-master/jobs/mozilla-aurora_remote/config.xml
++++ b/jenkins-master/jobs/mozilla-aurora_remote/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute remote tests for Aurora builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/mozilla-aurora_update/config.xml b/jenkins-master/jobs/mozilla-aurora_update/config.xml
+index b4db2b6..bcb2293 100644
+--- a/jenkins-master/jobs/mozilla-aurora_update/config.xml
++++ b/jenkins-master/jobs/mozilla-aurora_update/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute update tests for Aurora builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/mozilla-central_addons/config.xml b/jenkins-master/jobs/mozilla-central_addons/config.xml
+index 199a0a8..5e5a9d9 100644
+--- a/jenkins-master/jobs/mozilla-central_addons/config.xml
++++ b/jenkins-master/jobs/mozilla-central_addons/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute add-ons tests for Nightly builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/mozilla-central_endurance/config.xml b/jenkins-master/jobs/mozilla-central_endurance/config.xml
+index 4af85dc..eb6665d 100644
+--- a/jenkins-master/jobs/mozilla-central_endurance/config.xml
++++ b/jenkins-master/jobs/mozilla-central_endurance/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute endurance tests for Nightly builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/mozilla-central_functional/config.xml b/jenkins-master/jobs/mozilla-central_functional/config.xml
+index e0dd8b4..2188486 100644
+--- a/jenkins-master/jobs/mozilla-central_functional/config.xml
++++ b/jenkins-master/jobs/mozilla-central_functional/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute functional tests for Nightly builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/mozilla-central_remote/config.xml b/jenkins-master/jobs/mozilla-central_remote/config.xml
+index c984e48..b656592 100644
+--- a/jenkins-master/jobs/mozilla-central_remote/config.xml
++++ b/jenkins-master/jobs/mozilla-central_remote/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute remote tests for Nightly builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/mozilla-central_update/config.xml b/jenkins-master/jobs/mozilla-central_update/config.xml
+index bb6091f..92bf13f 100644
+--- a/jenkins-master/jobs/mozilla-central_update/config.xml
++++ b/jenkins-master/jobs/mozilla-central_update/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute update tests for Nightly builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/mozilla-esr24_addons/config.xml b/jenkins-master/jobs/mozilla-esr24_addons/config.xml
+index b8c829c..2ae3979 100644
+--- a/jenkins-master/jobs/mozilla-esr24_addons/config.xml
++++ b/jenkins-master/jobs/mozilla-esr24_addons/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute add-ons tests for ESR24 builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/mozilla-esr24_endurance/config.xml b/jenkins-master/jobs/mozilla-esr24_endurance/config.xml
+index ed0e433..b39f88b 100644
+--- a/jenkins-master/jobs/mozilla-esr24_endurance/config.xml
++++ b/jenkins-master/jobs/mozilla-esr24_endurance/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute endurance tests for ESR24 builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/mozilla-esr24_functional/config.xml b/jenkins-master/jobs/mozilla-esr24_functional/config.xml
+index 0b124b2..9eaeadf 100644
+--- a/jenkins-master/jobs/mozilla-esr24_functional/config.xml
++++ b/jenkins-master/jobs/mozilla-esr24_functional/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute functional tests for ESR24 builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/mozilla-esr24_remote/config.xml b/jenkins-master/jobs/mozilla-esr24_remote/config.xml
+index 1668388..2fa112e 100644
+--- a/jenkins-master/jobs/mozilla-esr24_remote/config.xml
++++ b/jenkins-master/jobs/mozilla-esr24_remote/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute remote tests for ESR24 builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/mozilla-esr24_update/config.xml b/jenkins-master/jobs/mozilla-esr24_update/config.xml
+index 70c5c1b..881a9b0 100644
+--- a/jenkins-master/jobs/mozilla-esr24_update/config.xml
++++ b/jenkins-master/jobs/mozilla-esr24_update/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute update tests for ESR24 builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/ondemand_addons/config.xml b/jenkins-master/jobs/ondemand_addons/config.xml
+index 673ee9d..68712ca 100644
+--- a/jenkins-master/jobs/ondemand_addons/config.xml
++++ b/jenkins-master/jobs/ondemand_addons/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute add-ons tests for release and candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>500</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/ondemand_endurance/config.xml b/jenkins-master/jobs/ondemand_endurance/config.xml
+index 45a2687..5544596 100644
+--- a/jenkins-master/jobs/ondemand_endurance/config.xml
++++ b/jenkins-master/jobs/ondemand_endurance/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute endurance tests for release and candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>500</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/ondemand_functional/config.xml b/jenkins-master/jobs/ondemand_functional/config.xml
+index 798123c..4437180 100644
+--- a/jenkins-master/jobs/ondemand_functional/config.xml
++++ b/jenkins-master/jobs/ondemand_functional/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute functional tests for release and candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>500</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/ondemand_l10n/config.xml b/jenkins-master/jobs/ondemand_l10n/config.xml
+index 16fc92a..aa6167e 100644
+--- a/jenkins-master/jobs/ondemand_l10n/config.xml
++++ b/jenkins-master/jobs/ondemand_l10n/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute l10n tests for release and candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>500</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/ondemand_remote/config.xml b/jenkins-master/jobs/ondemand_remote/config.xml
+index d54a011..3565f44 100644
+--- a/jenkins-master/jobs/ondemand_remote/config.xml
++++ b/jenkins-master/jobs/ondemand_remote/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute remote tests for release and candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>500</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/ondemand_update/config.xml b/jenkins-master/jobs/ondemand_update/config.xml
+index f1dcb4b..9da6be1 100644
+--- a/jenkins-master/jobs/ondemand_update/config.xml
++++ b/jenkins-master/jobs/ondemand_update/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute update tests for release and candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>500</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/project_addons/config.xml b/jenkins-master/jobs/project_addons/config.xml
+index dc0d67b..4532193 100644
+--- a/jenkins-master/jobs/project_addons/config.xml
++++ b/jenkins-master/jobs/project_addons/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute add-ons tests for Nightly builds based on a project branch.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/project_endurance/config.xml b/jenkins-master/jobs/project_endurance/config.xml
+index 58309bc..06155f5 100644
+--- a/jenkins-master/jobs/project_endurance/config.xml
++++ b/jenkins-master/jobs/project_endurance/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute endurance tests for Nightly builds based on a project branch.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/project_functional/config.xml b/jenkins-master/jobs/project_functional/config.xml
+index ed2a41e..bc3e976 100644
+--- a/jenkins-master/jobs/project_functional/config.xml
++++ b/jenkins-master/jobs/project_functional/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute functional tests for Nightly builds based on a project branch.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/project_remote/config.xml b/jenkins-master/jobs/project_remote/config.xml
+index e0922c2..2cd86cc 100644
+--- a/jenkins-master/jobs/project_remote/config.xml
++++ b/jenkins-master/jobs/project_remote/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute remote tests for Nightly builds based on a project branch.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/release-mozilla-beta_addons/config.xml b/jenkins-master/jobs/release-mozilla-beta_addons/config.xml
+index e7b5225..f4f3be0 100644
+--- a/jenkins-master/jobs/release-mozilla-beta_addons/config.xml
++++ b/jenkins-master/jobs/release-mozilla-beta_addons/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute add-ons tests for Beta candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/release-mozilla-beta_endurance/config.xml b/jenkins-master/jobs/release-mozilla-beta_endurance/config.xml
+index 9c6c46b..7f5646b 100644
+--- a/jenkins-master/jobs/release-mozilla-beta_endurance/config.xml
++++ b/jenkins-master/jobs/release-mozilla-beta_endurance/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute endurance tests for Beta candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/release-mozilla-beta_functional/config.xml b/jenkins-master/jobs/release-mozilla-beta_functional/config.xml
+index 61369d9..7aae707 100644
+--- a/jenkins-master/jobs/release-mozilla-beta_functional/config.xml
++++ b/jenkins-master/jobs/release-mozilla-beta_functional/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute functional tests for Beta candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/release-mozilla-beta_remote/config.xml b/jenkins-master/jobs/release-mozilla-beta_remote/config.xml
+index 8bc00b7..c4c19ed 100644
+--- a/jenkins-master/jobs/release-mozilla-beta_remote/config.xml
++++ b/jenkins-master/jobs/release-mozilla-beta_remote/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute remote tests for Beta candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/release-mozilla-esr24_addons/config.xml b/jenkins-master/jobs/release-mozilla-esr24_addons/config.xml
+index b8daad4..734d8a0 100644
+--- a/jenkins-master/jobs/release-mozilla-esr24_addons/config.xml
++++ b/jenkins-master/jobs/release-mozilla-esr24_addons/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute add-ons tests for ESR24 candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/release-mozilla-esr24_endurance/config.xml b/jenkins-master/jobs/release-mozilla-esr24_endurance/config.xml
+index ea3ff0f..0795814 100644
+--- a/jenkins-master/jobs/release-mozilla-esr24_endurance/config.xml
++++ b/jenkins-master/jobs/release-mozilla-esr24_endurance/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute endurance tests for ESR24 candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/release-mozilla-esr24_functional/config.xml b/jenkins-master/jobs/release-mozilla-esr24_functional/config.xml
+index bdfd380..7307111 100644
+--- a/jenkins-master/jobs/release-mozilla-esr24_functional/config.xml
++++ b/jenkins-master/jobs/release-mozilla-esr24_functional/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute functional tests for ESR24 candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/release-mozilla-esr24_remote/config.xml b/jenkins-master/jobs/release-mozilla-esr24_remote/config.xml
+index ac200fa..3533e2d 100644
+--- a/jenkins-master/jobs/release-mozilla-esr24_remote/config.xml
++++ b/jenkins-master/jobs/release-mozilla-esr24_remote/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute remote tests for ESR24 candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/release-mozilla-release_addons/config.xml b/jenkins-master/jobs/release-mozilla-release_addons/config.xml
+index fecb11f..0796290 100644
+--- a/jenkins-master/jobs/release-mozilla-release_addons/config.xml
++++ b/jenkins-master/jobs/release-mozilla-release_addons/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute add-ons tests for Release candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/release-mozilla-release_endurance/config.xml b/jenkins-master/jobs/release-mozilla-release_endurance/config.xml
+index f908d6f..b928e90 100644
+--- a/jenkins-master/jobs/release-mozilla-release_endurance/config.xml
++++ b/jenkins-master/jobs/release-mozilla-release_endurance/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute endurance tests for Release candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/release-mozilla-release_functional/config.xml b/jenkins-master/jobs/release-mozilla-release_functional/config.xml
+index 3179327..71500a2 100644
+--- a/jenkins-master/jobs/release-mozilla-release_functional/config.xml
++++ b/jenkins-master/jobs/release-mozilla-release_functional/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute functional tests for Release candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/release-mozilla-release_remote/config.xml b/jenkins-master/jobs/release-mozilla-release_remote/config.xml
+index 52ed053..877da77 100644
+--- a/jenkins-master/jobs/release-mozilla-release_remote/config.xml
++++ b/jenkins-master/jobs/release-mozilla-release_remote/config.xml
+@@ -4,7 +4,7 @@
+   <description>Execute remote tests for Release candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+diff --git a/jenkins-master/jobs/trigger-ondemand/config.xml b/jenkins-master/jobs/trigger-ondemand/config.xml
+index c8d148e..f5a3ade 100644
+--- a/jenkins-master/jobs/trigger-ondemand/config.xml
++++ b/jenkins-master/jobs/trigger-ondemand/config.xml
+@@ -4,7 +4,7 @@
+   <description>Trigger an on-demand test run.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>
+   <description>Execute endurance tests for Release candidate builds.</description>
+   <logRotator class="hudson.tasks.LogRotator">
+     <daysToKeep>-1</daysToKeep>
+-    <numToKeep>10</numToKeep>
++    <numToKeep>200</numToKeep>
+     <artifactDaysToKeep>-1</artifactDaysToKeep>
+     <artifactNumToKeep>-1</artifactNumToKeep>
+   </logRotator>

--- a/jenkins-master/jobs/get_mozmill-tests/config.xml
+++ b/jenkins-master/jobs/get_mozmill-tests/config.xml
@@ -4,7 +4,7 @@
   <description>Clone the Mozmill tests repository.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/mozilla-aurora_addons/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_addons/config.xml
@@ -4,7 +4,7 @@
   <description>Execute add-ons tests for Aurora builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/mozilla-aurora_endurance/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_endurance/config.xml
@@ -4,7 +4,7 @@
   <description>Execute endurance tests for Aurora builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/mozilla-aurora_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_functional/config.xml
@@ -4,7 +4,7 @@
   <description>Execute functional tests for Aurora builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/mozilla-aurora_l10n/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_l10n/config.xml
@@ -4,7 +4,7 @@
   <description>Execute l10n tests for Aurora builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/mozilla-aurora_remote/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_remote/config.xml
@@ -4,7 +4,7 @@
   <description>Execute remote tests for Aurora builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/mozilla-aurora_update/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_update/config.xml
@@ -4,7 +4,7 @@
   <description>Execute update tests for Aurora builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/mozilla-central_addons/config.xml
+++ b/jenkins-master/jobs/mozilla-central_addons/config.xml
@@ -4,7 +4,7 @@
   <description>Execute add-ons tests for Nightly builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/mozilla-central_endurance/config.xml
+++ b/jenkins-master/jobs/mozilla-central_endurance/config.xml
@@ -4,7 +4,7 @@
   <description>Execute endurance tests for Nightly builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/mozilla-central_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-central_functional/config.xml
@@ -4,7 +4,7 @@
   <description>Execute functional tests for Nightly builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/mozilla-central_remote/config.xml
+++ b/jenkins-master/jobs/mozilla-central_remote/config.xml
@@ -4,7 +4,7 @@
   <description>Execute remote tests for Nightly builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/mozilla-central_update/config.xml
+++ b/jenkins-master/jobs/mozilla-central_update/config.xml
@@ -4,7 +4,7 @@
   <description>Execute update tests for Nightly builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/mozilla-esr24_addons/config.xml
+++ b/jenkins-master/jobs/mozilla-esr24_addons/config.xml
@@ -4,7 +4,7 @@
   <description>Execute add-ons tests for ESR24 builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/mozilla-esr24_endurance/config.xml
+++ b/jenkins-master/jobs/mozilla-esr24_endurance/config.xml
@@ -4,7 +4,7 @@
   <description>Execute endurance tests for ESR24 builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/mozilla-esr24_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-esr24_functional/config.xml
@@ -4,7 +4,7 @@
   <description>Execute functional tests for ESR24 builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/mozilla-esr24_remote/config.xml
+++ b/jenkins-master/jobs/mozilla-esr24_remote/config.xml
@@ -4,7 +4,7 @@
   <description>Execute remote tests for ESR24 builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/mozilla-esr24_update/config.xml
+++ b/jenkins-master/jobs/mozilla-esr24_update/config.xml
@@ -4,7 +4,7 @@
   <description>Execute update tests for ESR24 builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/ondemand_addons/config.xml
+++ b/jenkins-master/jobs/ondemand_addons/config.xml
@@ -4,7 +4,7 @@
   <description>Execute add-ons tests for release and candidate builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>500</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/ondemand_endurance/config.xml
+++ b/jenkins-master/jobs/ondemand_endurance/config.xml
@@ -4,7 +4,7 @@
   <description>Execute endurance tests for release and candidate builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>500</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/ondemand_functional/config.xml
+++ b/jenkins-master/jobs/ondemand_functional/config.xml
@@ -4,7 +4,7 @@
   <description>Execute functional tests for release and candidate builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>500</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/ondemand_l10n/config.xml
+++ b/jenkins-master/jobs/ondemand_l10n/config.xml
@@ -4,7 +4,7 @@
   <description>Execute l10n tests for release and candidate builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>500</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/ondemand_remote/config.xml
+++ b/jenkins-master/jobs/ondemand_remote/config.xml
@@ -4,7 +4,7 @@
   <description>Execute remote tests for release and candidate builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>500</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/ondemand_update/config.xml
+++ b/jenkins-master/jobs/ondemand_update/config.xml
@@ -4,7 +4,7 @@
   <description>Execute update tests for release and candidate builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>500</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/project_addons/config.xml
+++ b/jenkins-master/jobs/project_addons/config.xml
@@ -4,7 +4,7 @@
   <description>Execute add-ons tests for Nightly builds based on a project branch.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/project_endurance/config.xml
+++ b/jenkins-master/jobs/project_endurance/config.xml
@@ -4,7 +4,7 @@
   <description>Execute endurance tests for Nightly builds based on a project branch.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/project_functional/config.xml
+++ b/jenkins-master/jobs/project_functional/config.xml
@@ -4,7 +4,7 @@
   <description>Execute functional tests for Nightly builds based on a project branch.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/project_remote/config.xml
+++ b/jenkins-master/jobs/project_remote/config.xml
@@ -4,7 +4,7 @@
   <description>Execute remote tests for Nightly builds based on a project branch.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/release-mozilla-beta_addons/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_addons/config.xml
@@ -4,7 +4,7 @@
   <description>Execute add-ons tests for Beta candidate builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/release-mozilla-beta_endurance/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_endurance/config.xml
@@ -4,7 +4,7 @@
   <description>Execute endurance tests for Beta candidate builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/release-mozilla-beta_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_functional/config.xml
@@ -4,7 +4,7 @@
   <description>Execute functional tests for Beta candidate builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/release-mozilla-beta_remote/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_remote/config.xml
@@ -4,7 +4,7 @@
   <description>Execute remote tests for Beta candidate builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/release-mozilla-esr24_addons/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr24_addons/config.xml
@@ -4,7 +4,7 @@
   <description>Execute add-ons tests for ESR24 candidate builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/release-mozilla-esr24_endurance/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr24_endurance/config.xml
@@ -4,7 +4,7 @@
   <description>Execute endurance tests for ESR24 candidate builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/release-mozilla-esr24_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr24_functional/config.xml
@@ -4,7 +4,7 @@
   <description>Execute functional tests for ESR24 candidate builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/release-mozilla-esr24_remote/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr24_remote/config.xml
@@ -4,7 +4,7 @@
   <description>Execute remote tests for ESR24 candidate builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/release-mozilla-release_addons/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_addons/config.xml
@@ -4,7 +4,7 @@
   <description>Execute add-ons tests for Release candidate builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/release-mozilla-release_endurance/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_endurance/config.xml
@@ -4,7 +4,7 @@
   <description>Execute endurance tests for Release candidate builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/release-mozilla-release_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_functional/config.xml
@@ -4,7 +4,7 @@
   <description>Execute functional tests for Release candidate builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/release-mozilla-release_remote/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_remote/config.xml
@@ -4,7 +4,7 @@
   <description>Execute remote tests for Release candidate builds.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>

--- a/jenkins-master/jobs/trigger-ondemand/config.xml
+++ b/jenkins-master/jobs/trigger-ondemand/config.xml
@@ -4,7 +4,7 @@
   <description>Trigger an on-demand test run.</description>
   <logRotator class="hudson.tasks.LogRotator">
     <daysToKeep>-1</daysToKeep>
-    <numToKeep>200</numToKeep>
+    <numToKeep>10</numToKeep>
     <artifactDaysToKeep>-1</artifactDaysToKeep>
     <artifactNumToKeep>-1</artifactNumToKeep>
   </logRotator>


### PR DESCRIPTION
This is for issue #416
Due to the last failure on staging, where because the HDD was full the master node was set offline by the system. We decided to reduce the number of jobs logs we keep.
