### PR TITLE
Add ja-JP-mac locale to release testruns (#439)

### DIFF
--- a/config/production/release.json
+++ b/config/production/release.json
@@ -80,6 +80,7 @@
                     "fr",
                     "it",
                     "ja",
+                    "ja-JP-mac",
                     "pl",
                     "pt-BR",
                     "ru"
@@ -126,6 +127,7 @@
                     "fr",
                     "it",
                     "ja",
+                    "ja-JP-mac",
                     "pl",
                     "pt-BR",
                     "ru"


### PR DESCRIPTION
This should fix #439

It will also find OSX builds, while this locale will not trigger anything on other platforms.
