### PR TITLE
Add missing Ubuntu 14.04 staging nodes (#453)

### DIFF
--- a/config/staging/jenkins.patch
+++ b/config/staging/jenkins.patch
@@ -1,8 +1,8 @@
 diff --git a/jenkins-master/config.xml b/jenkins-master/config.xml
-index f334d85..9a84f84 100644
+index 1ead5e1..7488531 100644
 --- a/jenkins-master/config.xml
 +++ b/jenkins-master/config.xml
-@@ -17,16 +17,212 @@
+@@ -17,16 +17,244 @@
    <clouds/>
    <slaves>
      <slave>
@@ -140,6 +140,38 @@ index f334d85..9a84f84 100644
 +      </nodeProperties>
 +    </slave>
 +    <slave>
++      <name>mm-ub-1404-32</name>
++      <description>Ubuntu 14.04 32bit</description>
++      <remoteFS>jenkins</remoteFS>
++      <numExecutors>1</numExecutors>
++      <mode>NORMAL</mode>
++      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
++      <launcher class="hudson.slaves.JNLPLauncher"/>
++      <label>linux ubuntu 14.04 32bit endurance</label>
++      <nodeProperties>
++        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
++          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
++          <offlineAddresses>mozmill-ci@mozilla.org</offlineAddresses>
++        </org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty>
++      </nodeProperties>
++    </slave>
++    <slave>
++      <name>mm-ub-1404-64</name>
++      <description>Ubuntu 14.04 64bit</description>
++      <remoteFS>jenkins</remoteFS>
++      <numExecutors>1</numExecutors>
++      <mode>NORMAL</mode>
++      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
++      <launcher class="hudson.slaves.JNLPLauncher"/>
++      <label>linux ubuntu 14.04 64bit endurance</label>
++      <nodeProperties>
++        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
++          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
++          <offlineAddresses>mozmill-ci@mozilla.org</offlineAddresses>
++        </org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty>
++      </nodeProperties>
++    </slave>
++    <slave>
 +      <name>mm-win-xp-32</name>
 +      <description>Windows XP 32bit</description>
 +      <remoteFS>c:\jenkins</remoteFS>
@@ -221,7 +253,7 @@ index f334d85..9a84f84 100644
      </slave>
    </slaves>
    <quietPeriod>5</quietPeriod>
-@@ -245,7 +441,12 @@
+@@ -245,7 +473,12 @@
    <primaryView>All</primaryView>
    <slaveAgentPort>0</slaveAgentPort>
    <label>master</label>


### PR DESCRIPTION
This PR as part of issue #453 also adds the missing 14.04 nodes for staging.
