### PR TITLE
Stop running endurance tests for all branches except mozilla-central (#466)

### DIFF
--- a/config/production/daily.json
+++ b/config/production/daily.json
@@ -113,7 +113,6 @@
                 "testruns": [
                     "update",
                     "functional",
-                    "endurance",
                     "remote",
                     "addons"
                 ],
@@ -154,7 +153,6 @@
                 "testruns": [
                     "update",
                     "functional",
-                    "endurance",
                     "remote",
                     "addons"
                 ],
@@ -195,7 +193,6 @@
                 "testruns": [
                     "update",
                     "functional",
-                    "endurance",
                     "remote",
                     "addons"
                 ],
@@ -236,7 +233,6 @@
                 "testruns": [
                     "update",
                     "functional",
-                    "endurance",
                     "remote",
                     "addons"
                 ],

--- a/config/production/release.json
+++ b/config/production/release.json
@@ -88,7 +88,6 @@
                 ],
                 "testruns": [
                     "functional",
-                    "endurance",
                     "remote",
                     "addons"
                 ],
@@ -135,7 +134,6 @@
                 ],
                 "testruns": [
                     "functional",
-                    "endurance",
                     "remote",
                     "addons"
                 ],
@@ -175,7 +173,6 @@
                 ],
                 "testruns": [
                     "functional",
-                    "endurance",
                     "remote",
                     "addons"
                 ],
@@ -215,7 +212,6 @@
                 ],
                 "testruns": [
                     "functional",
-                    "endurance",
                     "remote",
                     "addons"
                 ],

--- a/config/staging/daily.json
+++ b/config/staging/daily.json
@@ -148,7 +148,6 @@
                 "testruns": [
                     "update",
                     "functional",
-                    "endurance",
                     "remote",
                     "addons"
                 ],
@@ -185,7 +184,6 @@
                 "testruns": [
                     "update",
                     "functional",
-                    "endurance",
                     "remote",
                     "addons"
                 ],
@@ -222,7 +220,6 @@
                 "testruns": [
                     "update",
                     "functional",
-                    "endurance",
                     "remote",
                     "addons"
                 ],

--- a/config/staging/release.json
+++ b/config/staging/release.json
@@ -78,7 +78,6 @@
                 ],
                 "testruns": [
                     "functional",
-                    "endurance",
                     "remote",
                     "addons"
                 ],
@@ -112,7 +111,6 @@
                 ],
                 "testruns": [
                     "functional",
-                    "endurance",
                     "remote",
                     "addons"
                 ],
@@ -146,7 +144,6 @@
                 ],
                 "testruns": [
                     "functional",
-                    "endurance",
                     "remote",
                     "addons"
                 ],
@@ -180,7 +177,6 @@
                 ],
                 "testruns": [
                     "functional",
-                    "endurance",
                     "remote",
                     "addons"
                 ],


### PR DESCRIPTION
This PR fixes #466.
