### PR TITLE
Add endurance job back to production nightly (#466)

### DIFF
--- a/config/production/daily.json
+++ b/config/production/daily.json
@@ -113,6 +113,7 @@
                 "testruns": [
                     "update",
                     "functional",
+                    "endurance",
                     "remote",
                     "addons"
                 ],


### PR DESCRIPTION
This re-adds the endurance job on for Nightly builds.

@davehunt please review
