### PR TITLE
Replace fa with ar locale on staging (#476)

### DIFF
--- a/config/staging/daily.json
+++ b/config/staging/daily.json
@@ -141,6 +141,7 @@
             },
             "mozilla-aurora": {
                 "locales": [
+                    "ar",
                     "en-US",
                     "zh-CN"
                 ],
@@ -175,6 +176,7 @@
             },
             "mozilla-esr31": {
                 "locales": [
+                    "ar",
                     "en-US",
                     "zh-CN"
                 ],
@@ -209,6 +211,7 @@
             },
             "mozilla-esr24": {
                 "locales": [
+                    "ar",
                     "en-US",
                     "zh-CN"
                 ],


### PR DESCRIPTION
This removes `fa` as a tested locale from staging. Fixes #476.
I've marked `fa` as blackisted in the locale status doc https://docs.google.com/spreadsheets/d/18dQsatBMlcekK3hc-Zn-Qawq3b6rK_PBek6c2kJxMME/edit#gid=0

@whimboo please review when you get a chance.
