### PR TITLE
Rename staging OSX 10.7 machines to OSX 10.10 (#479)

### DIFF
--- a/config/staging/daily.json
+++ b/config/staging/daily.json
@@ -91,9 +91,9 @@
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
                         "mac && 10.8 && 64bit",
-                        "mac && 10.9 && 64bit"
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -126,9 +126,9 @@
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
                         "mac && 10.8 && 64bit",
-                        "mac && 10.9 && 64bit"
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -161,9 +161,9 @@
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
                         "mac && 10.8 && 64bit",
-                        "mac && 10.9 && 64bit"
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -196,9 +196,9 @@
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
                         "mac && 10.8 && 64bit",
-                        "mac && 10.9 && 64bit"
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -231,9 +231,9 @@
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
                         "mac && 10.8 && 64bit",
-                        "mac && 10.9 && 64bit"
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",

--- a/config/staging/jenkins.patch
+++ b/config/staging/jenkins.patch
@@ -1,5 +1,5 @@
 diff --git a/jenkins-master/config.xml b/jenkins-master/config.xml
-index 1ead5e1..7488531 100644
+index 4802111..0ebfe4b 100644
 --- a/jenkins-master/config.xml
 +++ b/jenkins-master/config.xml
 @@ -17,16 +17,244 @@
@@ -20,22 +20,6 @@ index 1ead5e1..7488531 100644
 -      <nodeProperties/>
 -      <userId>anonymous</userId>
 +      <label>mac 10.6 64bit endurance</label>
-+      <nodeProperties>
-+        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
-+          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
-+          <offlineAddresses>mozmill-ci@mozilla.org</offlineAddresses>
-+        </org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty>
-+      </nodeProperties>
-+    </slave>
-+    <slave>
-+      <name>mm-osx-107</name>
-+      <description>OS X 10.7</description>
-+      <remoteFS>jenkins</remoteFS>
-+      <numExecutors>1</numExecutors>
-+      <mode>NORMAL</mode>
-+      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-+      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>mac 10.7 64bit endurance</label>
 +      <nodeProperties>
 +        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
 +          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
@@ -68,6 +52,22 @@ index 1ead5e1..7488531 100644
 +      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
 +      <launcher class="hudson.slaves.JNLPLauncher"/>
 +      <label>mac 10.9 64bit endurance</label>
++      <nodeProperties>
++        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
++          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
++          <offlineAddresses>mozmill-ci@mozilla.org</offlineAddresses>
++        </org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty>
++      </nodeProperties>
++    </slave>
++    <slave>
++      <name>mm-osx-1010</name>
++      <description>OS X 10.10</description>
++      <remoteFS>jenkins</remoteFS>
++      <numExecutors>1</numExecutors>
++      <mode>NORMAL</mode>
++      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
++      <launcher class="hudson.slaves.JNLPLauncher"/>
++      <label>mac 10.10 64bit endurance</label>
 +      <nodeProperties>
 +        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
 +          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
@@ -253,7 +253,7 @@ index 1ead5e1..7488531 100644
      </slave>
    </slaves>
    <quietPeriod>5</quietPeriod>
-@@ -245,7 +473,12 @@
+@@ -289,7 +517,12 @@
    <primaryView>All</primaryView>
    <slaveAgentPort>0</slaveAgentPort>
    <label>master</label>

--- a/config/staging/release.json
+++ b/config/staging/release.json
@@ -91,9 +91,9 @@
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
                         "mac && 10.8 && 64bit",
-                        "mac && 10.9 && 64bit"
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -123,9 +123,9 @@
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
                         "mac && 10.8 && 64bit",
-                        "mac && 10.9 && 64bit"
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -155,9 +155,9 @@
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
                         "mac && 10.8 && 64bit",
-                        "mac && 10.9 && 64bit"
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -187,9 +187,9 @@
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
                         "mac && 10.8 && 64bit",
-                        "mac && 10.9 && 64bit"
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",


### PR DESCRIPTION
Updating OSX 10.7 machines names for staging, as well as the patch.
