### PR TITLE
Fix active platforms for l10n tests (#519)

### DIFF
--- a/config/production/l10n.json
+++ b/config/production/l10n.json
@@ -58,15 +58,15 @@
                     "l10n"
                 ],
                 "platforms": {
-                    "linux": [
-                        "linux && ubuntu && 12.04 && 32bit"
+                    "linux64": [
+                        "linux && ubuntu && 13.10 && 64bit"
                     ],
                     "mac": [
-                        "mac && 10.8 && 64bit"
+                        "mac && 10.9 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
-                        "windows && 7 && 32bit"
+                        "windows && 8.1 && 32bit"
                     ]
                 }
             }

--- a/config/staging/l10n.json
+++ b/config/staging/l10n.json
@@ -61,9 +61,6 @@
                     "l10n"
                 ],
                 "platforms": {
-                    "linux": [
-                        "linux && ubuntu && 13.10 && 64bit"
-                    ],
                     "linux64": [
                         "linux && ubuntu && 13.10 && 64bit"
                     ],


### PR DESCRIPTION
Lets fix the wrong platform assignment and update the platforms so we run on latest. This fixes issue #519.
