### PR TITLE
Enable Firefox win64 builds in Mozmill CI (#547)

### DIFF
--- a/config/production/daily.json
+++ b/config/production/daily.json
@@ -11,7 +11,8 @@
             "linux64",
             "macosx",
             "macosx64",
-            "win32"
+            "win32",
+            "win64"
         ],
         "products": [
             "firefox"
@@ -102,6 +103,10 @@
                         "windows && 8 && 64bit",
                         "windows && 8.1 && 32bit",
                         "windows && 8.1 && 64bit"
+                    ],
+                    "win64": [
+                        "windows && 7 && 64bit",
+                        "windows && 8.1 && 64bit"
                     ]
                 }
             },
@@ -139,6 +144,10 @@
                         "windows && 8 && 32bit",
                         "windows && 8 && 64bit",
                         "windows && 8.1 && 32bit",
+                        "windows && 8.1 && 64bit"
+                    ],
+                    "win64": [
+                        "windows && 7 && 64bit",
                         "windows && 8.1 && 64bit"
                     ]
                 }
@@ -178,6 +187,10 @@
                         "windows && 8 && 32bit",
                         "windows && 8 && 64bit",
                         "windows && 8.1 && 32bit",
+                        "windows && 8.1 && 64bit"
+                    ],
+                    "win64": [
+                        "windows && 7 && 64bit",
                         "windows && 8.1 && 64bit"
                     ]
                 }

--- a/config/staging/daily.json
+++ b/config/staging/daily.json
@@ -12,7 +12,8 @@
             "linux64",
             "macosx",
             "macosx64",
-            "win32"
+            "win32",
+            "win64"
         ],
         "products": [
             "firefox"
@@ -100,6 +101,10 @@
                         "windows && 7 && 64bit",
                         "windows && 8.1 && 32bit",
                         "windows && 8.1 && 64bit"
+                    ],
+                    "win64": [
+                        "windows && 7 && 64bit",
+                        "windows && 8.1 && 64bit"
                     ]
                 }
             },
@@ -135,6 +140,10 @@
                         "windows && 7 && 64bit",
                         "windows && 8.1 && 32bit",
                         "windows && 8.1 && 64bit"
+                    ],
+                    "win64": [
+                        "windows && 7 && 64bit",
+                        "windows && 8.1 && 64bit"
                     ]
                 }
             },
@@ -169,6 +178,10 @@
                         "windows && 7 && 32bit",
                         "windows && 7 && 64bit",
                         "windows && 8.1 && 32bit",
+                        "windows && 8.1 && 64bit"
+                    ],
+                    "win64": [
+                        "windows && 7 && 64bit",
                         "windows && 8.1 && 64bit"
                     ]
                 }


### PR DESCRIPTION
This will fix issue #547. @andreeamatei can you please have a look at? 