### PR TITLE
Blacklist Romanian (ro) locale for beta and release testing (#556)

### DIFF
--- a/config/production/release.json
+++ b/config/production/release.json
@@ -75,7 +75,8 @@
                 "blacklist": {
                     "locales": [
                         "az",
-                        "cy"
+                        "cy",
+                        "ro"
                     ]
                 },
                 "testruns": [
@@ -113,7 +114,8 @@
                 "blacklist": {
                     "locales": [
                         "az",
-                        "cy"
+                        "cy",
+                        "ro"
                     ]
                 },
                 "testruns": [


### PR DESCRIPTION
This fixes issue #556. @AutomatedTester can you please have a look at?