### PR TITLE
Stop running endurance tests via Pulse message (#561)

### DIFF
--- a/config/production/daily.json
+++ b/config/production/daily.json
@@ -51,14 +51,6 @@
                     "value": "http://mozauto.iriscouch.com/mozmill-daily/"
                 }
             },
-            "endurance": {
-                "ENTITIES": {
-                    "value": 10
-                },
-                "ITERATIONS": {
-                    "value": 10
-                }
-            },
             "update": {
                 "BUILD_ID": {
                     "key": "previous_buildid"
@@ -116,7 +108,6 @@
                 "testruns": [
                     "update",
                     "functional",
-                    "endurance",
                     "remote",
                     "addons"
                 ],

--- a/config/staging/daily.json
+++ b/config/staging/daily.json
@@ -52,14 +52,6 @@
                     "value": "http://mozauto.iriscouch.com/mozmill-staging/"
                 }
             },
-            "endurance": {
-                "ENTITIES": {
-                    "value": 2
-                },
-                "ITERATIONS": {
-                    "value": 2
-                }
-            },
             "update": {
                 "BUILD_ID": {
                     "key": "previous_buildid"
@@ -114,7 +106,6 @@
                 "testruns": [
                     "update",
                     "functional",
-                    "endurance",
                     "remote",
                     "addons"
                 ],


### PR DESCRIPTION
This fixes issue #561. @AutomatedTester can you please have a look at? Keep in mind this only removes the pulse triggers and configuration, but leaves the jobs for manual testing.