### PR TITLE
Temporarily disable tests for beta builds on Windows 7 (#563)

### DIFF
--- a/config/production/release.json
+++ b/config/production/release.json
@@ -101,8 +101,6 @@
                     "win32": [
                         "windows && xp && 32bit",
                         "windows && vista && 32bit",
-                        "windows && 7 && 32bit",
-                        "windows && 7 && 64bit",
                         "windows && 8 && 32bit",
                         "windows && 8 && 64bit",
                         "windows && 8.1 && 32bit",


### PR DESCRIPTION
This fixes issue #563. @AutomatedTester or @davehunt could one of you review this PR? We have to get it landed on production ASAP to stop the massive crashes for Win7 builds. Thanks.