### PR TITLE
Enable Firefox win64 builds for beta and release (#566)

### DIFF
--- a/config/production/daily.json
+++ b/config/production/daily.json
@@ -97,6 +97,7 @@
                     ],
                     "win64": [
                         "windows && 7 && 64bit",
+                        "windows && 8 && 64bit",
                         "windows && 8.1 && 64bit"
                     ]
                 }
@@ -137,6 +138,7 @@
                     ],
                     "win64": [
                         "windows && 7 && 64bit",
+                        "windows && 8 && 64bit",
                         "windows && 8.1 && 64bit"
                     ]
                 }
@@ -180,6 +182,7 @@
                     ],
                     "win64": [
                         "windows && 7 && 64bit",
+                        "windows && 8 && 64bit",
                         "windows && 8.1 && 64bit"
                     ]
                 }

--- a/config/production/release.json
+++ b/config/production/release.json
@@ -11,7 +11,8 @@
             "linux64",
             "macosx",
             "macosx64",
-            "win32"
+            "win32",
+            "win64"
         ],
         "products": [
             "firefox"
@@ -107,6 +108,11 @@
                         "windows && 8 && 64bit",
                         "windows && 8.1 && 32bit",
                         "windows && 8.1 && 64bit"
+                    ],
+                    "win64": [
+                        "windows && 7 && 64bit",
+                        "windows && 8 && 64bit",
+                        "windows && 8.1 && 64bit"
                     ]
                 }
             },
@@ -145,6 +151,11 @@
                         "windows && 8 && 32bit",
                         "windows && 8 && 64bit",
                         "windows && 8.1 && 32bit",
+                        "windows && 8.1 && 64bit"
+                    ],
+                    "win64": [
+                        "windows && 7 && 64bit",
+                        "windows && 8 && 64bit",
                         "windows && 8.1 && 64bit"
                     ]
                 }

--- a/config/staging/release.json
+++ b/config/staging/release.json
@@ -11,7 +11,8 @@
             "linux64",
             "macosx",
             "macosx64",
-            "win32"
+            "win32",
+            "win64"
         ],
         "products": [
             "firefox"
@@ -100,6 +101,10 @@
                         "windows && 7 && 64bit",
                         "windows && 8.1 && 32bit",
                         "windows && 8.1 && 64bit"
+                    ],
+                    "win64": [
+                        "windows && 7 && 64bit",
+                        "windows && 8.1 && 64bit"
                     ]
                 }
             },
@@ -131,6 +136,10 @@
                         "windows && 7 && 32bit",
                         "windows && 7 && 64bit",
                         "windows && 8.1 && 32bit",
+                        "windows && 8.1 && 64bit"
+                    ],
+                    "win64": [
+                        "windows && 7 && 64bit",
                         "windows && 8.1 && 64bit"
                     ]
                 }


### PR DESCRIPTION
This PR fixes issue #566. @AutomatedTester can you please have a look at?