### PR TITLE
Use zh-TW instead of zh-CN for Aurora builds (#571)

### DIFF
--- a/config/production/daily.json
+++ b/config/production/daily.json
@@ -148,7 +148,7 @@
                     "de",
                     "en-US",
                     "ru",
-                    "zh-CN"
+                    "zh-TW"
                 ],
                 "testruns": [
                     "update",

--- a/config/staging/daily.json
+++ b/config/staging/daily.json
@@ -140,7 +140,7 @@
                 "locales": [
                     "ar",
                     "en-US",
-                    "zh-CN"
+                    "zh-TW"
                 ],
                 "testruns": [
                     "update",


### PR DESCRIPTION
This PR fixes issue #571 by only updating the config for Aurora builds from zh-CN to zh-TW.

@davehunt, this is a very short one. Could you have a quick look at it?