### PR TITLE
Rename production OSX 10.7 machines to OSX 10.10 (#479)

### DIFF
--- a/config/example.json
+++ b/config/example.json
@@ -77,10 +77,10 @@
                 ],
                 "platforms": {
                     "mac": [
-                        "mac && 10.5 && 32bit",
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
-                        "mac && 10.8 && 64bit"
+                        "mac && 10.8 && 64bit",
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -106,10 +106,10 @@
                 ],
                 "platforms": {
                     "mac": [
-                        "mac && 10.5 && 32bit",
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
-                        "mac && 10.8 && 64bit"
+                        "mac && 10.8 && 64bit",
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",

--- a/config/ondemand/functional-all.ini
+++ b/config/ondemand/functional-all.ini
@@ -6,7 +6,7 @@ report=http://mozauto.iriscouch.com/mozmill-release/
 platform=mac
 31.0esr=en-US
 
-[mac 10.7 64bit]
+[mac 10.10 64bit]
 platform=mac
 31.0esr=en-US
 

--- a/config/ondemand/l10n-mac.ini
+++ b/config/ondemand/l10n-mac.ini
@@ -2,7 +2,7 @@
 script=l10n
 report=http://mozauto.iriscouch.com/mozmill-release/
 
-[mac 10.7 64bit]
+[mac 10.10 64bit]
 platform=mac
 22.0#1=en-US
 22.0=en-GB en-US

--- a/config/production/daily.json
+++ b/config/production/daily.json
@@ -81,9 +81,9 @@
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
                         "mac && 10.8 && 64bit",
-                        "mac && 10.9 && 64bit"
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -122,9 +122,9 @@
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
                         "mac && 10.8 && 64bit",
-                        "mac && 10.9 && 64bit"
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -166,9 +166,9 @@
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
                         "mac && 10.8 && 64bit",
-                        "mac && 10.9 && 64bit"
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -210,9 +210,9 @@
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
                         "mac && 10.8 && 64bit",
-                        "mac && 10.9 && 64bit"
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",

--- a/config/production/jenkins.patch
+++ b/config/production/jenkins.patch
@@ -82,14 +82,14 @@ index 18017a4..59b9aac 100644
 +      </nodeProperties>
 +    </slave>
 +    <slave>
-+      <name>mm-osx-107-1</name>
-+      <description>OS X 10.7</description>
++      <name>mm-osx-1010-1</name>
++      <description>OS X 10.10</description>
 +      <remoteFS>jenkins</remoteFS>
 +      <numExecutors>1</numExecutors>
 +      <mode>NORMAL</mode>
 +      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
 +      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>mac 10.7 64bit endurance</label>
++      <label>mac 10.10 64bit endurance</label>
 +      <nodeProperties>
 +        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
 +          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
@@ -98,14 +98,14 @@ index 18017a4..59b9aac 100644
 +      </nodeProperties>
 +    </slave>
 +    <slave>
-+      <name>mm-osx-107-2</name>
-+      <description>OS X 10.7</description>
++      <name>mm-osx-1010-2</name>
++      <description>OS X 10.10</description>
 +      <remoteFS>jenkins</remoteFS>
 +      <numExecutors>1</numExecutors>
 +      <mode>NORMAL</mode>
 +      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
 +      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>mac 10.7 64bit endurance</label>
++      <label>mac 10.10 64bit endurance</label>
 +      <nodeProperties>
 +        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
 +          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
@@ -114,14 +114,14 @@ index 18017a4..59b9aac 100644
 +      </nodeProperties>
 +    </slave>
 +    <slave>
-+      <name>mm-osx-107-3</name>
-+      <description>OS X 10.7</description>
++      <name>mm-osx-1010-3</name>
++      <description>OS X 10.10</description>
 +      <remoteFS>jenkins</remoteFS>
 +      <numExecutors>1</numExecutors>
 +      <mode>NORMAL</mode>
 +      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
 +      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>mac 10.7 64bit</label>
++      <label>mac 10.10 64bit</label>
 +      <nodeProperties>
 +        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
 +          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
@@ -130,14 +130,14 @@ index 18017a4..59b9aac 100644
 +      </nodeProperties>
 +    </slave>
 +    <slave>
-+      <name>mm-osx-107-4</name>
-+      <description>OS X 10.7</description>
++      <name>mm-osx-1010-4</name>
++      <description>OS X 10.10</description>
 +      <remoteFS>jenkins</remoteFS>
 +      <numExecutors>1</numExecutors>
 +      <mode>NORMAL</mode>
 +      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
 +      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>mac 10.7 64bit</label>
++      <label>mac 10.10 64bit</label>
 +      <nodeProperties>
 +        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
 +          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>

--- a/config/production/l10n.json
+++ b/config/production/l10n.json
@@ -62,7 +62,7 @@
                         "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
-                        "mac && 10.9 && 64bit"
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",

--- a/config/production/release.json
+++ b/config/production/release.json
@@ -96,9 +96,9 @@
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
                         "mac && 10.8 && 64bit",
-                        "mac && 10.9 && 64bit"
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -140,9 +140,9 @@
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
                         "mac && 10.8 && 64bit",
-                        "mac && 10.9 && 64bit"
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -183,9 +183,9 @@
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
                         "mac && 10.8 && 64bit",
-                        "mac && 10.9 && 64bit"
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.10 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",
@@ -221,9 +221,9 @@
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
-                        "mac && 10.7 && 64bit",
                         "mac && 10.8 && 64bit",
-                        "mac && 10.9 && 64bit"
+                        "mac && 10.9 && 64bit",
+                        "mac && 10.7 && 64bit"
                     ],
                     "win32": [
                         "windows && xp && 32bit",


### PR DESCRIPTION
This PR fixes issue #479 and will enable our 10.10 nodes in Mozmill CI once upgraded.