### PR TITLE
Limit locale testing for beta and release to only a handful of locales (#576)

### DIFF
--- a/config/production/release.json
+++ b/config/production/release.json
@@ -74,13 +74,17 @@
         },
         "by_branch": {
             "release-mozilla-beta": {
-                "blacklist": {
-                    "locales": [
-                        "az",
-                        "cy",
-                        "ro"
-                    ]
-                },
+                "locales": [
+                    "ar",
+                    "de",
+                    "en-US",
+                    "es-ES",
+                    "fr",
+                    "it",
+                    "pl",
+                    "pt-BR",
+                    "ru"
+                ],
                 "testruns": [
                     "functional",
                     "remote"
@@ -114,13 +118,17 @@
                 }
             },
             "release-mozilla-release": {
-                "blacklist": {
-                    "locales": [
-                        "az",
-                        "cy",
-                        "ro"
-                    ]
-                },
+                "locales": [
+                    "ar",
+                    "de",
+                    "en-US",
+                    "es-ES",
+                    "fr",
+                    "it",
+                    "pl",
+                    "pt-BR",
+                    "ru"
+                ],
                 "testruns": [
                     "functional",
                     "remote"
@@ -155,10 +163,7 @@
             },
             "release-mozilla-esr38": {
                 "locales": [
-                    "de",
-                    "en-US",
-                    "ru",
-                    "zh-TW"
+                    "en-US"
                 ],
                 "testruns": [
                     "functional",
@@ -190,10 +195,7 @@
             },
             "release-mozilla-esr31": {
                 "locales": [
-                    "de",
-                    "en-US",
-                    "ru",
-                    "zh-TW"
+                    "en-US"
                 ],
                 "testruns": [
                     "functional",


### PR DESCRIPTION
This cuts down the list of supported locales for beta and release builds to only a couple of the tier 1. As talked with @AutomatedTester on IRC we have to leave some so I can have test results on treeherder for inspection. Also those locales are stable for a long time and I don't expect a breakage. If we get one, there is always the chance to get it off the list too.