### PR TITLE
Remove Ubuntu 14.10 machines (#603)

### DIFF
--- a/config/ondemand/functional-all.ini
+++ b/config/ondemand/functional-all.ini
@@ -22,14 +22,6 @@ platform=linux
 platform=linux64
 31.0esr=en-US
 
-[linux ubuntu 14.10 32bit]
-platform=linux
-31.0esr=en-US
-
-[linux ubuntu 14.10 64bit]
-platform=linux64
-31.0esr=en-US
-
 [windows xp 32bit]
 platform=win32
 31.0esr=en-us

--- a/config/production/daily.json
+++ b/config/production/daily.json
@@ -75,12 +75,10 @@
                 ],
                 "platforms": {
                     "linux": [
-                        "linux && ubuntu && 14.04 && 32bit",
-                        "linux && ubuntu && 14.10 && 32bit"
+                        "linux && ubuntu && 14.04 && 32bit"
                     ],
                     "linux64": [
-                        "linux && ubuntu && 14.04 && 64bit",
-                        "linux && ubuntu && 14.10 && 64bit"
+                        "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
@@ -112,12 +110,10 @@
                 ],
                 "platforms": {
                     "linux": [
-                        "linux && ubuntu && 14.04 && 32bit",
-                        "linux && ubuntu && 14.10 && 32bit"
+                        "linux && ubuntu && 14.04 && 32bit"
                     ],
                     "linux64": [
-                        "linux && ubuntu && 14.04 && 64bit",
-                        "linux && ubuntu && 14.10 && 64bit"
+                        "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
@@ -152,12 +148,10 @@
                 ],
                 "platforms": {
                     "linux": [
-                        "linux && ubuntu && 14.04 && 32bit",
-                        "linux && ubuntu && 14.10 && 32bit"
+                        "linux && ubuntu && 14.04 && 32bit"
                     ],
                     "linux64": [
-                        "linux && ubuntu && 14.04 && 64bit",
-                        "linux && ubuntu && 14.10 && 64bit"
+                        "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",

--- a/config/production/jenkins.patch
+++ b/config/production/jenkins.patch
@@ -1,8 +1,8 @@
 diff --git a/jenkins-master/config.xml b/jenkins-master/config.xml
-index 05404e1..c0228cf 100644
+index 05404e1..b953887 100644
 --- a/jenkins-master/config.xml
 +++ b/jenkins-master/config.xml
-@@ -17,40 +17,836 @@
+@@ -17,40 +17,708 @@
    <clouds/>
    <slaves>
      <slave>
@@ -402,134 +402,6 @@ index 05404e1..c0228cf 100644
 +      </nodeProperties>
 +    </slave>
 +    <slave>
-+      <name>mm-ub-1410-32-1</name>
-+      <description>Ubuntu 14.10 32bit</description>
-+      <remoteFS>jenkins</remoteFS>
-+      <numExecutors>1</numExecutors>
-+      <mode>NORMAL</mode>
-+      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-+      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>linux ubuntu 14.10 32bit endurance</label>
-+      <nodeProperties>
-+        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
-+          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
-+          <offlineAddresses>mozmill-ci@mozilla.org</offlineAddresses>
-+        </org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty>
-+      </nodeProperties>
-+    </slave>
-+    <slave>
-+      <name>mm-ub-1410-32-2</name>
-+      <description>Ubuntu 14.10 32bit</description>
-+      <remoteFS>jenkins</remoteFS>
-+      <numExecutors>1</numExecutors>
-+      <mode>NORMAL</mode>
-+      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-+      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>linux ubuntu 14.10 32bit endurance</label>
-+      <nodeProperties>
-+        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
-+          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
-+          <offlineAddresses>mozmill-ci@mozilla.org</offlineAddresses>
-+        </org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty>
-+      </nodeProperties>
-+    </slave>
-+    <slave>
-+      <name>mm-ub-1410-32-3</name>
-+      <description>Ubuntu 14.10 32bit</description>
-+      <remoteFS>jenkins</remoteFS>
-+      <numExecutors>1</numExecutors>
-+      <mode>NORMAL</mode>
-+      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-+      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>linux ubuntu 14.10 32bit</label>
-+      <nodeProperties>
-+        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
-+          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
-+          <offlineAddresses>mozmill-ci@mozilla.org</offlineAddresses>
-+        </org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty>
-+      </nodeProperties>
-+    </slave>
-+    <slave>
-+      <name>mm-ub-1410-32-4</name>
-+      <description>Ubuntu 14.10 32bit</description>
-+      <remoteFS>jenkins</remoteFS>
-+      <numExecutors>1</numExecutors>
-+      <mode>NORMAL</mode>
-+      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-+      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>linux ubuntu 14.10 32bit</label>
-+      <nodeProperties>
-+        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
-+          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
-+          <offlineAddresses>mozmill-ci@mozilla.org</offlineAddresses>
-+        </org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty>
-+      </nodeProperties>
-+    </slave>
-+    <slave>
-+      <name>mm-ub-1410-64-1</name>
-+      <description>Ubuntu 14.10 64bit</description>
-+      <remoteFS>jenkins</remoteFS>
-+      <numExecutors>1</numExecutors>
-+      <mode>NORMAL</mode>
-+      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-+      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>linux ubuntu 14.10 64bit endurance</label>
-+      <nodeProperties>
-+        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
-+          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
-+          <offlineAddresses>mozmill-ci@mozilla.org</offlineAddresses>
-+        </org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty>
-+      </nodeProperties>
-+    </slave>
-+    <slave>
-+      <name>mm-ub-1410-64-2</name>
-+      <description>Ubuntu 14.10 64bit</description>
-+      <remoteFS>jenkins</remoteFS>
-+      <numExecutors>1</numExecutors>
-+      <mode>NORMAL</mode>
-+      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-+      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>linux ubuntu 14.10 64bit endurance</label>
-+      <nodeProperties>
-+        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
-+          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
-+          <offlineAddresses>mozmill-ci@mozilla.org</offlineAddresses>
-+        </org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty>
-+      </nodeProperties>
-+    </slave>
-+    <slave>
-+      <name>mm-ub-1410-64-3</name>
-+      <description>Ubuntu 14.10 64bit</description>
-+      <remoteFS>jenkins</remoteFS>
-+      <numExecutors>1</numExecutors>
-+      <mode>NORMAL</mode>
-+      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-+      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>linux ubuntu 14.10 64bit</label>
-+      <nodeProperties>
-+        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
-+          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
-+          <offlineAddresses>mozmill-ci@mozilla.org</offlineAddresses>
-+        </org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty>
-+      </nodeProperties>
-+    </slave>
-+    <slave>
-+      <name>mm-ub-1410-64-4</name>
-+      <description>Ubuntu 14.10 64bit</description>
-+      <remoteFS>jenkins</remoteFS>
-+      <numExecutors>1</numExecutors>
-+      <mode>NORMAL</mode>
-+      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-+      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>linux ubuntu 14.10 64bit</label>
-+      <nodeProperties>
-+        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
-+          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
-+          <offlineAddresses>mozmill-ci@mozilla.org</offlineAddresses>
-+        </org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty>
-+      </nodeProperties>
-+    </slave>
-+    <slave>
 +      <name>mm-win-xp-32-1</name>
 +      <description>Windows XP 32bit</description>
 +      <remoteFS>c:\jenkins</remoteFS>
@@ -854,7 +726,7 @@ index 05404e1..c0228cf 100644
      </slave>
    </slaves>
    <quietPeriod>5</quietPeriod>
-@@ -269,7 +1065,12 @@
+@@ -269,7 +937,12 @@
    <primaryView>All</primaryView>
    <slaveAgentPort>0</slaveAgentPort>
    <label>master</label>
@@ -868,7 +740,7 @@ index 05404e1..c0228cf 100644
    <globalNodeProperties>
      <hudson.slaves.EnvironmentVariablesNodeProperty>
        <envVars serialization="custom">
-@@ -282,7 +1083,7 @@
+@@ -282,7 +955,7 @@
            <string>MOZMILL_AUTOMATION_VERSION</string>
            <string>2.0.10</string>
            <string>NOTIFICATION_ADDRESS</string>

--- a/config/production/release.json
+++ b/config/production/release.json
@@ -86,12 +86,10 @@
                 ],
                 "platforms": {
                     "linux": [
-                        "linux && ubuntu && 14.04 && 32bit",
-                        "linux && ubuntu && 14.10 && 32bit"
+                        "linux && ubuntu && 14.04 && 32bit"
                     ],
                     "linux64": [
-                        "linux && ubuntu && 14.04 && 64bit",
-                        "linux && ubuntu && 14.10 && 64bit"
+                        "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
@@ -130,12 +128,10 @@
                 ],
                 "platforms": {
                     "linux": [
-                        "linux && ubuntu && 14.04 && 32bit",
-                        "linux && ubuntu && 14.10 && 32bit"
+                        "linux && ubuntu && 14.04 && 32bit"
                     ],
                     "linux64": [
-                        "linux && ubuntu && 14.04 && 64bit",
-                        "linux && ubuntu && 14.10 && 64bit"
+                        "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
@@ -166,12 +162,10 @@
                 ],
                 "platforms": {
                     "linux": [
-                        "linux && ubuntu && 14.04 && 32bit",
-                        "linux && ubuntu && 14.10 && 32bit"
+                        "linux && ubuntu && 14.04 && 32bit"
                     ],
                     "linux64": [
-                        "linux && ubuntu && 14.04 && 64bit",
-                        "linux && ubuntu && 14.10 && 64bit"
+                        "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
@@ -198,12 +192,10 @@
                 ],
                 "platforms": {
                     "linux": [
-                        "linux && ubuntu && 14.04 && 32bit",
-                        "linux && ubuntu && 14.10 && 32bit"
+                        "linux && ubuntu && 14.04 && 32bit"
                     ],
                     "linux64": [
-                        "linux && ubuntu && 14.04 && 64bit",
-                        "linux && ubuntu && 14.10 && 64bit"
+                        "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",

--- a/config/staging/daily.json
+++ b/config/staging/daily.json
@@ -76,12 +76,10 @@
                 ],
                 "platforms": {
                     "linux": [
-                        "linux && ubuntu && 14.04 && 32bit",
-                        "linux && ubuntu && 14.10 && 32bit"
+                        "linux && ubuntu && 14.04 && 32bit"
                     ],
                     "linux64": [
-                        "linux && ubuntu && 14.04 && 64bit",
-                        "linux && ubuntu && 14.10 && 64bit"
+                        "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
@@ -113,12 +111,10 @@
                 ],
                 "platforms": {
                     "linux": [
-                        "linux && ubuntu && 14.04 && 32bit",
-                        "linux && ubuntu && 14.10 && 32bit"
+                        "linux && ubuntu && 14.04 && 32bit"
                     ],
                     "linux64": [
-                        "linux && ubuntu && 14.04 && 64bit",
-                        "linux && ubuntu && 14.10 && 64bit"
+                        "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
@@ -152,12 +148,10 @@
                 ],
                 "platforms": {
                     "linux": [
-                        "linux && ubuntu && 14.04 && 32bit",
-                        "linux && ubuntu && 14.10 && 32bit"
+                        "linux && ubuntu && 14.04 && 32bit"
                     ],
                     "linux64": [
-                        "linux && ubuntu && 14.04 && 64bit",
-                        "linux && ubuntu && 14.10 && 64bit"
+                        "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",

--- a/config/staging/jenkins.patch
+++ b/config/staging/jenkins.patch
@@ -1,8 +1,8 @@
 diff --git a/jenkins-master/config.xml b/jenkins-master/config.xml
-index 05404e1..fd7bea2 100644
+index 05404e1..366b916 100644
 --- a/jenkins-master/config.xml
 +++ b/jenkins-master/config.xml
-@@ -17,40 +17,212 @@
+@@ -17,40 +17,180 @@
    <clouds/>
    <slaves>
      <slave>
@@ -114,38 +114,6 @@ index 05404e1..fd7bea2 100644
 +      </nodeProperties>
 +    </slave>
 +    <slave>
-+      <name>mm-ub-1410-32</name>
-+      <description>Ubuntu 14.10 32bit</description>
-+      <remoteFS>jenkins</remoteFS>
-+      <numExecutors>1</numExecutors>
-+      <mode>NORMAL</mode>
-+      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-+      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>linux ubuntu 14.10 32bit endurance</label>
-+      <nodeProperties>
-+        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
-+          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
-+          <offlineAddresses>mozmill-ci@mozilla.org</offlineAddresses>
-+        </org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty>
-+      </nodeProperties>
-+    </slave>
-+    <slave>
-+      <name>mm-ub-1410-64</name>
-+      <description>Ubuntu 14.10 64bit</description>
-+      <remoteFS>jenkins</remoteFS>
-+      <numExecutors>1</numExecutors>
-+      <mode>NORMAL</mode>
-+      <retentionStrategy class="hudson.slaves.RetentionStrategy$Always"/>
-+      <launcher class="hudson.slaves.JNLPLauncher"/>
-+      <label>linux ubuntu 14.10 64bit endurance</label>
-+      <nodeProperties>
-+        <org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty plugin="mail-watcher-plugin@1.5">
-+          <onlineAddresses>mozmill-ci@mozilla.org</onlineAddresses>
-+          <offlineAddresses>mozmill-ci@mozilla.org</offlineAddresses>
-+        </org.jenkinsci.plugins.mailwatcher.WatcherNodeProperty>
-+      </nodeProperties>
-+    </slave>
-+    <slave>
 +      <name>mm-win-xp-32</name>
 +      <description>Windows XP 32bit</description>
 +      <remoteFS>c:\jenkins</remoteFS>
@@ -230,7 +198,7 @@ index 05404e1..fd7bea2 100644
      </slave>
    </slaves>
    <quietPeriod>5</quietPeriod>
-@@ -269,7 +441,12 @@
+@@ -269,7 +409,12 @@
    <primaryView>All</primaryView>
    <slaveAgentPort>0</slaveAgentPort>
    <label>master</label>

--- a/config/staging/release.json
+++ b/config/staging/release.json
@@ -78,12 +78,10 @@
                 ],
                 "platforms": {
                     "linux": [
-                        "linux && ubuntu && 14.04 && 32bit",
-                        "linux && ubuntu && 14.10 && 32bit"
+                        "linux && ubuntu && 14.04 && 32bit"
                     ],
                     "linux64": [
-                        "linux && ubuntu && 14.04 && 64bit",
-                        "linux && ubuntu && 14.10 && 64bit"
+                        "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
@@ -114,12 +112,10 @@
                 ],
                 "platforms": {
                     "linux": [
-                        "linux && ubuntu && 14.04 && 32bit",
-                        "linux && ubuntu && 14.10 && 32bit"
+                        "linux && ubuntu && 14.04 && 32bit"
                     ],
                     "linux64": [
-                        "linux && ubuntu && 14.04 && 64bit",
-                        "linux && ubuntu && 14.10 && 64bit"
+                        "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
@@ -150,12 +146,10 @@
                 ],
                 "platforms": {
                     "linux": [
-                        "linux && ubuntu && 14.04 && 32bit",
-                        "linux && ubuntu && 14.10 && 32bit"
+                        "linux && ubuntu && 14.04 && 32bit"
                     ],
                     "linux64": [
-                        "linux && ubuntu && 14.04 && 64bit",
-                        "linux && ubuntu && 14.10 && 64bit"
+                        "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",
@@ -182,12 +176,10 @@
                 ],
                 "platforms": {
                     "linux": [
-                        "linux && ubuntu && 14.04 && 32bit",
-                        "linux && ubuntu && 14.10 && 32bit"
+                        "linux && ubuntu && 14.04 && 32bit"
                     ],
                     "linux64": [
-                        "linux && ubuntu && 14.04 && 64bit",
-                        "linux && ubuntu && 14.10 && 64bit"
+                        "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
                         "mac && 10.6 && 64bit",


### PR DESCRIPTION
This PR fixes issue #603 by removing all Ubuntu 14.10 (32bit + 64 bit) machines.