### PR TITLE
Fix handling of multiple locales for funsize updates (#627)

### DIFF
--- a/jenkins-master/jobs/scripts/workspace/runtests.py
+++ b/jenkins-master/jobs/scripts/workspace/runtests.py
@@ -111,7 +111,7 @@ class Runner(object):
                                           key=os.environ['TREEHERDER_KEY_%s' % repository],
                                           secret=os.environ['TREEHERDER_SECRET_%s' % repository])
                 th.submit_results(job)
-            except Exception, e:
+            except Exception as e:
                 print('Cannot post job information to treeherder: %s' % e.message)
 
         command = [
@@ -182,7 +182,7 @@ class Runner(object):
         try:
             remote_filename = '%s_%s' % (str(uuid.uuid4()), os.path.basename(path))
             return self.s3_bucket.upload(path, remote_filename)
-        except Exception, e:
+        except Exception as e:
             print 'Failure uploading "%s" to S3: %s' % (path, str(e))
             return None
 

--- a/jenkins-master/jobs/scripts/workspace/runtests_release.py
+++ b/jenkins-master/jobs/scripts/workspace/runtests_release.py
@@ -113,7 +113,7 @@ class Runner(object):
                                           key=os.environ['TREEHERDER_KEY_%s' % repository],
                                           secret=os.environ['TREEHERDER_SECRET_%s' % repository])
                 th.submit_results(job)
-            except Exception, e:
+            except Exception as e:
                 print('Cannot post job information to treeherder: %s' % e.message)
 
         command = [
@@ -184,7 +184,7 @@ class Runner(object):
         try:
             remote_filename = '%s_%s' % (str(uuid.uuid4()), os.path.basename(path))
             return self.s3_bucket.upload(path, remote_filename)
-        except Exception, e:
+        except Exception as e:
             print 'Failure uploading "%s" to S3: %s' % (path, str(e))
             return None
 

--- a/pulse.py
+++ b/pulse.py
@@ -166,7 +166,7 @@ class FirefoxAutomation:
         try:
             if not os.path.exists(filename):
                 JSONFile(filename).write(json_data)
-        except Exception, e:
+        except Exception as e:
             self.logger.warning("Log file could not be written: {}.".format(str(e)))
 
         # Lets keep it after saving the log information so we might be able to


### PR DESCRIPTION
This PR is another part for issue #627 and changes the following things:

* Updated cc'ed routing key for new naming format
* no more locale checks in the pre-processing method given that those are no longer part of the cc'ed routing keys
* The product will not be part of the cc'ed routing key
* Better check for 'workerId' as indicator for the funsize-balrog blob. 'status' might be also part of the update manifest in the future.
* Fixed locale loop so we do not early abort in case of exceptions - we have to always process all locales
