### PR TITLE
Pass revision id from pulse to jobs for treeherder submission (#621)

### DIFF
--- a/config/production/pulse.json
+++ b/config/production/pulse.json
@@ -44,6 +44,9 @@
                         "PLATFORM": {
                             "key": "platform",
                             "transform": "get_platform_identifier"
+                        },
+                        "REVISION": {
+                            "key": "revision"
                         }
                     },
                     "update": {
@@ -55,9 +58,6 @@
                         },
                         "TARGET_BUILD_ID": {
                             "key": "to_buildid"
-                        },
-                        "TARGET_BUILD_REVISION": {
-                            "key": "revision"
                         }
                     }
                 }
@@ -107,6 +107,9 @@
                         "PLATFORM": {
                             "key": "platform",
                             "transform": "get_platform_identifier"
+                        },
+                        "REVISION": {
+                            "key": "revision"
                         }
                     },
                     "update": {
@@ -118,9 +121,6 @@
                         },
                         "TARGET_BUILD_ID": {
                             "key": "to_buildid"
-                        },
-                        "TARGET_BUILD_REVISION": {
-                            "key": "revision"
                         }
                     }
                 }
@@ -177,6 +177,9 @@
                         "PLATFORM": {
                             "key": "platform",
                             "transform": "get_platform_identifier"
+                        },
+                        "REVISION": {
+                            "key": "revision"
                         }
                     }
                 }
@@ -233,6 +236,9 @@
                         "PLATFORM": {
                             "key": "platform",
                             "transform": "get_platform_identifier"
+                        },
+                        "REVISION": {
+                            "key": "revision"
                         }
                     }
                 }
@@ -281,6 +287,9 @@
                         "PLATFORM": {
                             "key": "platform",
                             "transform": "get_platform_identifier"
+                        },
+                        "REVISION": {
+                            "key": "revision"
                         }
                     }
                 }

--- a/config/staging/pulse.json
+++ b/config/staging/pulse.json
@@ -44,6 +44,9 @@
                         "PLATFORM": {
                             "key": "platform",
                             "transform": "get_platform_identifier"
+                        },
+                        "REVISION": {
+                            "key": "revision"
                         }
                     },
                     "update": {
@@ -55,9 +58,6 @@
                         },
                         "TARGET_BUILD_ID": {
                             "key": "to_buildid"
-                        },
-                        "TARGET_BUILD_REVISION": {
-                            "key": "revision"
                         }
                     }
                 }
@@ -106,6 +106,9 @@
                         "PLATFORM": {
                             "key": "platform",
                             "transform": "get_platform_identifier"
+                        },
+                        "REVISION": {
+                            "key": "revision"
                         }
                     },
                     "update": {
@@ -117,9 +120,6 @@
                         },
                         "TARGET_BUILD_ID": {
                             "key": "to_buildid"
-                        },
-                        "TARGET_BUILD_REVISION": {
-                            "key": "revision"
                         }
                     }
                 }
@@ -168,6 +168,9 @@
                         "PLATFORM": {
                             "key": "platform",
                             "transform": "get_platform_identifier"
+                        },
+                        "REVISION": {
+                            "key": "revision"
                         }
                     }
                 }
@@ -216,6 +219,9 @@
                         "PLATFORM": {
                             "key": "platform",
                             "transform": "get_platform_identifier"
+                        },
+                        "REVISION": {
+                            "key": "revision"
                         }
                     }
                 }
@@ -264,6 +270,9 @@
                         "PLATFORM": {
                             "key": "platform",
                             "transform": "get_platform_identifier"
+                        },
+                        "REVISION": {
+                            "key": "revision"
                         }
                     }
                 }

--- a/jenkins-master/jobs/mozilla-aurora_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_functional/config.xml
@@ -64,6 +64,11 @@
             </a>
           </choices>
         </hudson.model.ChoiceParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>REVISION</name>
+          <description>The revision of Firefox which is used for the report to Treeherder.</description>
+          <defaultValue>None</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <EnvInjectJobProperty plugin="envinject@1.88">
@@ -118,7 +123,7 @@
       <selector class="hudson.plugins.copyartifact.StatusBuildSelector"/>
     </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python runtests.py --type=functional --branch=mozilla-aurora --platform=$PLATFORM --build-type=$BUILD_TYPE --build-id=$BUILD_ID --build-locale=$LOCALE</commandLine>
+      <commandLine>python runtests.py --type=functional --branch=mozilla-aurora --platform=$PLATFORM --build-type=$BUILD_TYPE --build-id=$BUILD_ID --build-locale=$LOCALE --build-revision=$REVISION</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/mozilla-aurora_update/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_update/config.xml
@@ -70,13 +70,13 @@
           </choices>
         </hudson.model.ChoiceParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>TARGET_BUILD_ID</name>
-          <description>The expected build id of Firefox after the update.</description>
+          <name>REVISION</name>
+          <description>The expected revision of Firefox after the upgrade, which is also used for the report to Treeherder.</description>
           <defaultValue>None</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>TARGET_BUILD_REVISION</name>
-          <description>The expected revision of Firefox after the update.</description>
+          <name>TARGET_BUILD_ID</name>
+          <description>The expected build id of Firefox after the update.</description>
           <defaultValue>None</defaultValue>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
@@ -135,7 +135,7 @@ NSPR_LOG_FILE=http.log</propertiesContent>
       <selector class="hudson.plugins.copyartifact.StatusBuildSelector"/>
     </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python runtests.py --type=update --branch=mozilla-aurora --platform=$PLATFORM --build-type=$BUILD_TYPE --build-id=$BUILD_ID --build-locale=$LOCALE --update-channel=$CHANNEL --update-target-build-id=$TARGET_BUILD_ID --update-target-revision=$TARGET_BUILD_REVISION</commandLine>
+      <commandLine>python runtests.py --type=update --branch=mozilla-aurora --platform=$PLATFORM --build-type=$BUILD_TYPE --build-id=$BUILD_ID --build-locale=$LOCALE --build-revision=$REVISION --update-channel=$CHANNEL --update-target-build-id=$TARGET_BUILD_ID</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/mozilla-central_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-central_functional/config.xml
@@ -64,6 +64,11 @@
             </a>
           </choices>
         </hudson.model.ChoiceParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>REVISION</name>
+          <description>The revision of Firefox which is used for the report to Treeherder.</description>
+          <defaultValue>None</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <EnvInjectJobProperty plugin="envinject@1.88">
@@ -118,7 +123,7 @@
       <selector class="hudson.plugins.copyartifact.StatusBuildSelector"/>
     </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python runtests.py --type=functional --branch=mozilla-central --platform=$PLATFORM --build-type=$BUILD_TYPE --build-id=$BUILD_ID --build-locale=$LOCALE</commandLine>
+      <commandLine>python runtests.py --type=functional --branch=mozilla-central --platform=$PLATFORM --build-type=$BUILD_TYPE --build-id=$BUILD_ID --build-locale=$LOCALE --build-revision=$REVISION</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/mozilla-central_update/config.xml
+++ b/jenkins-master/jobs/mozilla-central_update/config.xml
@@ -70,13 +70,13 @@
           </choices>
         </hudson.model.ChoiceParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>TARGET_BUILD_ID</name>
-          <description>The expected build id of Firefox after the update.</description>
+          <name>REVISION</name>
+          <description>The expected revision of Firefox after the upgrade, which is also used for the report to Treeherder.</description>
           <defaultValue>None</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
-          <name>TARGET_BUILD_REVISION</name>
-          <description>The expected revision of Firefox after the update.</description>
+          <name>TARGET_BUILD_ID</name>
+          <description>The expected build id of Firefox after the update.</description>
           <defaultValue>None</defaultValue>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
@@ -135,7 +135,7 @@ NSPR_LOG_FILE=http.log</propertiesContent>
       <selector class="hudson.plugins.copyartifact.StatusBuildSelector"/>
     </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python runtests.py --type=update --branch=mozilla-central --platform=$PLATFORM --build-type=$BUILD_TYPE --build-id=$BUILD_ID --build-locale=$LOCALE --update-channel=$CHANNEL --update-target-build-id=$TARGET_BUILD_ID  --update-target-revision=$TARGET_BUILD_REVISION</commandLine>
+      <commandLine>python runtests.py --type=update --branch=mozilla-central --platform=$PLATFORM --build-type=$BUILD_TYPE --build-id=$BUILD_ID --build-locale=$LOCALE --build-revision=$REVISION --update-channel=$CHANNEL --update-target-build-id=$TARGET_BUILD_ID</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/project_functional/config.xml
+++ b/jenkins-master/jobs/project_functional/config.xml
@@ -69,6 +69,11 @@
             </a>
           </choices>
         </hudson.model.ChoiceParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>REVISION</name>
+          <description>The revision of Firefox which is used for the report to Treeherder.</description>
+          <defaultValue>None</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <EnvInjectJobProperty plugin="envinject@1.88">
@@ -123,7 +128,7 @@
       <selector class="hudson.plugins.copyartifact.StatusBuildSelector"/>
     </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python runtests.py --type=functional --branch=$BRANCH --platform=$PLATFORM --build-type=$BUILD_TYPE --build-id=$BUILD_ID --build-locale=$LOCALE</commandLine>
+      <commandLine>python runtests.py --type=functional --branch=$BRANCH --platform=$PLATFORM --build-type=$BUILD_TYPE --build-id=$BUILD_ID --build-locale=$LOCALE --build-revision=$REVISION</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/project_update/config.xml
+++ b/jenkins-master/jobs/project_update/config.xml
@@ -70,14 +70,14 @@
           </choices>
         </hudson.model.ChoiceParameterDefinition>
         <hudson.model.StringParameterDefinition>
+          <name>REVISION</name>
+          <description>The expected revision of Firefox after the upgrade, which is also used for the report to Treeherder.</description>
+          <defaultValue>None</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>TARGET_BUILD_ID</name>
           <description>The expected build id of Firefox after the update.</description>
           <defaultValue></defaultValue>
-        </hudson.model.StringParameterDefinition>
-        <hudson.model.StringParameterDefinition>
-          <name>TARGET_BUILD_REVISION</name>
-          <description>The expected revision of Firefox after the update.</description>
-          <defaultValue>None</defaultValue>
         </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
@@ -135,7 +135,7 @@ NSPR_LOG_FILE=http.log</propertiesContent>
       <selector class="hudson.plugins.copyartifact.StatusBuildSelector"/>
     </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python runtests.py --type=update --branch=$BRANCH --platform=$PLATFORM --build-type=$BUILD_TYPE --build-id=$BUILD_ID --build-locale=$LOCALE --update-channel=$CHANNEL --update-target-build-id=$TARGET_BUILD_ID --update-target-revision=$TARGET_BUILD_REVISION</commandLine>
+      <commandLine>python runtests.py --type=update --branch=$BRANCH --platform=$PLATFORM --build-type=$BUILD_TYPE --build-id=$BUILD_ID --build-locale=$LOCALE --build-revision=$REVISION --update-channel=$CHANNEL --update-target-build-id=$TARGET_BUILD_ID</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/release-mozilla-beta_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_functional/config.xml
@@ -64,6 +64,11 @@
             </a>
           </choices>
         </hudson.model.ChoiceParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>REVISION</name>
+          <description>The revision of Firefox which is used for the report to Treeherder.</description>
+          <defaultValue>None</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <EnvInjectJobProperty plugin="envinject@1.88">
@@ -118,7 +123,7 @@
       <selector class="hudson.plugins.copyartifact.StatusBuildSelector"/>
     </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python runtests_release.py --type=functional --platform=$PLATFORM --build-type=$BUILD_TYPE --build-version=$BUILD_VERSION --build-number=$BUILD_NUMBER --build-locale=$LOCALE</commandLine>
+      <commandLine>python runtests_release.py --type=functional --platform=$PLATFORM --build-type=$BUILD_TYPE --build-version=$BUILD_VERSION --build-number=$BUILD_NUMBER --build-locale=$LOCALE --build-revision=$REVISION</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/release-mozilla-esr38_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr38_functional/config.xml
@@ -64,6 +64,11 @@
             </a>
           </choices>
         </hudson.model.ChoiceParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>REVISION</name>
+          <description>The revision of Firefox which is used for the report to Treeherder.</description>
+          <defaultValue>None</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <EnvInjectJobProperty plugin="envinject@1.88">
@@ -118,7 +123,7 @@
       <selector class="hudson.plugins.copyartifact.StatusBuildSelector"/>
     </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python runtests_release.py --type=functional --platform=$PLATFORM --build-type=$BUILD_TYPE --build-version=$BUILD_VERSION --build-number=$BUILD_NUMBER --build-locale=$LOCALE</commandLine>
+      <commandLine>python runtests_release.py --type=functional --platform=$PLATFORM --build-type=$BUILD_TYPE --build-version=$BUILD_VERSION --build-number=$BUILD_NUMBER --build-locale=$LOCALE --build-revision=$REVISION</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/release-mozilla-release_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_functional/config.xml
@@ -64,6 +64,11 @@
             </a>
           </choices>
         </hudson.model.ChoiceParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>REVISION</name>
+          <description>The revision of Firefox which is used for the report to Treeherder.</description>
+          <defaultValue>None</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <EnvInjectJobProperty plugin="envinject@1.88">
@@ -118,7 +123,7 @@
       <selector class="hudson.plugins.copyartifact.StatusBuildSelector"/>
     </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python runtests_release.py --type=functional --platform=$PLATFORM --build-type=$BUILD_TYPE --build-version=$BUILD_VERSION --build-number=$BUILD_NUMBER --build-locale=$LOCALE</commandLine>
+      <commandLine>python runtests_release.py --type=functional --platform=$PLATFORM --build-type=$BUILD_TYPE --build-version=$BUILD_VERSION --build-number=$BUILD_NUMBER --build-locale=$LOCALE --build-revision=$REVISION</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/scripts/workspace/runtests.py
+++ b/jenkins-master/jobs/scripts/workspace/runtests.py
@@ -81,9 +81,10 @@ class Runner(object):
         version_info = mozversion.get_version(binary=binary)
         repository = version_info['application_repository'].split('/')[-1]
 
-        if options.type == 'update':
-            changeset = options.update_target_revision[:12]
+        if options.build_revision != 'None':
+            changeset = options.build_revision[:12]
         else:
+            # In case there is no revision specified try to get it from the application
             changeset = version_info['application_changeset'][:12]
 
         job = None
@@ -211,6 +212,9 @@ def main():
                              dest='build_locale',
                              default='en-US',
                              help='The locale of the build. Default: %default')
+    build_options.add_option('--build-revision',
+                             dest='build_revision',
+                             help='The revision of the build')
     build_options.add_option('--build-type',
                              dest='build_type',
                              choices=['daily', 'tinderbox', 'try'],
@@ -232,15 +236,9 @@ def main():
     update_options.add_option('--update-target-version',
                               dest='update_target_version',
                               help='The expected version of the updated build')
-    update_options.add_option('--update-target-revision',
-                              dest='update_target_revision',
-                              help='The expected revision of the updated build')
     parser.add_option_group(update_options)
 
     (options, args) = parser.parse_args()
-
-    if options.type == 'update' and options.update_target_revision is None:
-        parser.error('--update-target-revision is a mandatory option')
 
     try:
         path = os.path.abspath(os.path.join(here, 'venv'))

--- a/jenkins-master/jobs/scripts/workspace/runtests_release.py
+++ b/jenkins-master/jobs/scripts/workspace/runtests_release.py
@@ -83,10 +83,11 @@ class Runner(object):
         version_info = mozversion.get_version(binary=binary)
         repository = version_info['application_repository'].split('/')[-1]
 
-        # There is no target revision present in the pulse message for release
-        # builds. But given that we actually don't run update tests for those builds,
-        # we can simply retrieve it from the source build
-        changeset = version_info['application_changeset'][:12]
+        if options.build_revision != 'None':
+            changeset = options.build_revision[:12]
+        else:
+            # In case there is no revision specified try to get it from the application
+            changeset = version_info['application_changeset'][:12]
 
         job = None
         th = None
@@ -207,6 +208,9 @@ def main():
     build_options.add_option('--build-number',
                              dest='build_number',
                              help='The build number of the candidate build')
+    build_options.add_option('--build-revision',
+                             dest='build_revision',
+                             help='The revision of the build')
     build_options.add_option('--build-type',
                              dest='build_type',
                              choices=['candidate', 'release'],


### PR DESCRIPTION
This PR will fix issue #621. It will be safer to rely as much as possible on the revision as given by the pulse notification. 