### PR TITLE
Pass update_number through Jenkins for treeherder reporting (#627)

### DIFF
--- a/config/production/pulse.json
+++ b/config/production/pulse.json
@@ -58,6 +58,9 @@
                         },
                         "TARGET_BUILD_ID": {
                             "key": "to_buildid"
+                        },
+                        "UPDATE_NUMBER": {
+                            "key": "update_number"
                         }
                     }
                 }
@@ -121,6 +124,9 @@
                         },
                         "TARGET_BUILD_ID": {
                             "key": "to_buildid"
+                        },
+                        "UPDATE_NUMBER": {
+                            "key": "update_number"
                         }
                     }
                 }

--- a/config/staging/pulse.json
+++ b/config/staging/pulse.json
@@ -58,6 +58,9 @@
                         },
                         "TARGET_BUILD_ID": {
                             "key": "to_buildid"
+                        },
+                        "UPDATE_NUMBER": {
+                            "key": "update_number"
                         }
                     }
                 }
@@ -120,6 +123,9 @@
                         },
                         "TARGET_BUILD_ID": {
                             "key": "to_buildid"
+                        },
+                        "UPDATE_NUMBER": {
+                            "key": "update_number"
                         }
                     }
                 }

--- a/jenkins-master/jobs/mozilla-aurora_update/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_update/config.xml
@@ -79,6 +79,11 @@
           <description>The expected build id of Firefox after the update.</description>
           <defaultValue>None</defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>UPDATE_NUMBER</name>
+          <description>The number of the partial update: today - N days</description>
+          <defaultValue>None</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <EnvInjectJobProperty plugin="envinject@1.88">
@@ -135,7 +140,7 @@ NSPR_LOG_FILE=http.log</propertiesContent>
       <selector class="hudson.plugins.copyartifact.StatusBuildSelector"/>
     </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python runtests.py --type=update --branch=mozilla-aurora --platform=$PLATFORM --build-type=$BUILD_TYPE --build-id=$BUILD_ID --build-locale=$LOCALE --build-revision=$REVISION --update-channel=$CHANNEL --update-target-build-id=$TARGET_BUILD_ID</commandLine>
+      <commandLine>python runtests.py --type=update --branch=mozilla-aurora --platform=$PLATFORM --build-type=$BUILD_TYPE --build-id=$BUILD_ID --build-locale=$LOCALE --build-revision=$REVISION --update-channel=$CHANNEL --update-target-build-id=$TARGET_BUILD_ID --update-number=$UPDATE_NUMBER</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/mozilla-central_update/config.xml
+++ b/jenkins-master/jobs/mozilla-central_update/config.xml
@@ -79,6 +79,11 @@
           <description>The expected build id of Firefox after the update.</description>
           <defaultValue>None</defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>UPDATE_NUMBER</name>
+          <description>The number of the partial update: today - N days</description>
+          <defaultValue>None</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <EnvInjectJobProperty plugin="envinject@1.88">
@@ -135,7 +140,7 @@ NSPR_LOG_FILE=http.log</propertiesContent>
       <selector class="hudson.plugins.copyartifact.StatusBuildSelector"/>
     </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python runtests.py --type=update --branch=mozilla-central --platform=$PLATFORM --build-type=$BUILD_TYPE --build-id=$BUILD_ID --build-locale=$LOCALE --build-revision=$REVISION --update-channel=$CHANNEL --update-target-build-id=$TARGET_BUILD_ID</commandLine>
+      <commandLine>python runtests.py --type=update --branch=mozilla-central --platform=$PLATFORM --build-type=$BUILD_TYPE --build-id=$BUILD_ID --build-locale=$LOCALE --build-revision=$REVISION --update-channel=$CHANNEL --update-target-build-id=$TARGET_BUILD_ID --update-number=$UPDATE_NUMBER</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/scripts/workspace/runtests.py
+++ b/jenkins-master/jobs/scripts/workspace/runtests.py
@@ -95,10 +95,11 @@ class Runner(object):
 
         if os.environ.get('TREEHERDER_URL'):
             # Setup job for treeherder and post 'running' status
-            job = FirefoxUITestJob(product_name=version_info['application_name'],
+            job = FirefoxUITestJob(job_type=options.type,
+                                   product_name=version_info['application_name'],
                                    locale=options.build_locale,
-                                   group_name='Firefox UI Test - %s' % options.type,
-                                   group_symbol='F%s' % options.type[0])
+                                   update_number=options.update_number
+                                   )
 
             if os.environ.get('BUILD_URL'):
                 job.add_details(title='CI Build',
@@ -230,6 +231,9 @@ def main():
     update_options.add_option('--update-channel',
                               dest='update_channel',
                               help='The update channel to use for the update test')
+    update_options.add_option('--update-number',
+                              dest='update_number',
+                              help='The number of the partial update: today - N days.')
     update_options.add_option('--update-target-build-id',
                               dest='update_target_build_id',
                               help='The expected BUILDID of the updated build')
@@ -239,6 +243,10 @@ def main():
     parser.add_option_group(update_options)
 
     (options, args) = parser.parse_args()
+
+    # Fix defaults as passed in by Jenkins
+    if options.update_number == 'None':
+        options.update_number = None
 
     try:
         path = os.path.abspath(os.path.join(here, 'venv'))

--- a/jenkins-master/jobs/scripts/workspace/runtests_release.py
+++ b/jenkins-master/jobs/scripts/workspace/runtests_release.py
@@ -97,10 +97,11 @@ class Runner(object):
 
         if os.environ.get('TREEHERDER_URL'):
             # Setup job for treeherder and post 'running' status
-            job = FirefoxUITestJob(product_name=version_info['application_name'],
+            job = FirefoxUITestJob(job_type=options.type,
+                                   product_name=version_info['application_name'],
                                    locale=options.build_locale,
-                                   group_name='Firefox UI Test - %s' % options.type,
-                                   group_symbol='F%s' % options.type[0])
+                                   update_number=options.update_number
+                                   )
 
             if os.environ.get('BUILD_URL'):
                 job.add_details(title='CI Build',
@@ -226,6 +227,9 @@ def main():
     update_options.add_option('--update-channel',
                               dest='update_channel',
                               help='The update channel to use for the update test')
+    update_options.add_option('--update-number',
+                              dest='update_number',
+                              help='The number of the partial update: today - N days.')
     update_options.add_option('--update-target-build-id',
                               dest='update_target_build_id',
                               help='The expected BUILDID of the updated build')
@@ -235,6 +239,10 @@ def main():
     parser.add_option_group(update_options)
 
     (options, args) = parser.parse_args()
+
+    # Fix defaults as passed in by Jenkins
+    if options.update_number == 'None':
+        options.update_number = None
 
     try:
         path = os.path.abspath(os.path.join(here, 'venv'))

--- a/jenkins-master/jobs/scripts/workspace/treeherder.py
+++ b/jenkins-master/jobs/scripts/workspace/treeherder.py
@@ -20,7 +20,7 @@ REVISON_FRAGMENT = '/#/jobs?repo=%s&revision=%s'
 
 class FirefoxUITestJob(TreeherderJob):
 
-    def __init__(self, product_name, locale, group_name, group_symbol):
+    def __init__(self, job_type, product_name, locale, update_number=None):
         TreeherderJob.__init__(self, data={})
 
         self._details = []
@@ -41,13 +41,26 @@ class FirefoxUITestJob(TreeherderJob):
         # TODO debug or others?
         self.add_option_collection({'opt': True})
 
+        group_name = 'Firefox UI Test - {type}'.format(type=job_type)
+        group_symbol = 'F{type_id}'.format(type_id=job_type[0])
+
+        # Bug 1174973 - for now we need unique job names even in different groups
+        job_name = '{group} ({locale}{update_number})'.format(
+            group=group_name,
+            locale=locale,
+            update_number='-{}'.format(update_number) if update_number else ''
+        )
+        job_symbol = '{locale}{update_number}'.format(
+            locale=locale,
+            update_number='-{}'.format(update_number) if update_number else ''
+        )
+
         # TODO: Add e10s group later
         self.add_group_name(group_name)
         self.add_group_symbol(group_symbol)
 
-        # Bug 1174973 - for now we need unique job names even in different groups
-        self.add_job_name("%s (%s)" % (group_name, locale))
-        self.add_job_symbol(locale)
+        self.add_job_name(job_name)
+        self.add_job_symbol(job_symbol)
 
         self.add_start_timestamp(int(time.time()))
 


### PR DESCRIPTION
Thís will be the last PR for issue #627. It will pass the update number for partial updates to Jenkins so we can have a separation on Treeherder for the 4 different update tests on a single locale. An example how it will look like can be seen here:

https://treeherder.allizom.org/#/jobs?repo=mozilla-central&revision=f8086bd3c84f&filter-job_group_symbol=Ff&filter-job_group_symbol=Fr&filter-job_group_symbol=Fu

Just expand the Fu group for Linux64 and you will find `th-3`.