### PR TITLE
Emails for broken builds have to contain the installer URL (#656)

### DIFF
--- a/jenkins-master/jobs/mozilla-aurora_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_functional/config.xml
@@ -114,7 +114,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Marionette ${PROJECT_NAME} testrun for ${BUILD_URL} on ${NODE_NAME} was aborted.
+            <body>Marionette ${PROJECT_NAME} testrun for ${INSTALLER_URL} on ${NODE_NAME} was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -146,7 +146,7 @@ ${BUILD_URL}</body>
       </configuredTriggers>
       <contentType>default</contentType>
       <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME} on ${NODE_NAME}</defaultSubject>
-      <defaultContent>Marionette ${PROJECT_NAME} testrun for ${BUILD_URL} on ${NODE_NAME} completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultContent>Marionette ${PROJECT_NAME} testrun for ${INSTALLER_URL} on ${NODE_NAME} completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-aurora_update/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_update/config.xml
@@ -125,7 +125,7 @@ NSPR_LOG_FILE=http.log</propertiesContent>
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Marionette ${PROJECT_NAME} testrun for ${BUILD_URL} on ${NODE_NAME} was aborted.
+            <body>Marionette ${PROJECT_NAME} testrun for ${INSTALLER_URL} on ${NODE_NAME} was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -157,7 +157,7 @@ ${BUILD_URL}</body>
       </configuredTriggers>
       <contentType>default</contentType>
       <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME} on ${NODE_NAME}</defaultSubject>
-      <defaultContent>Marionette ${PROJECT_NAME} testrun for ${BUILD_URL} on ${NODE_NAME} completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultContent>Marionette ${PROJECT_NAME} testrun for ${INSTALLER_URL} on ${NODE_NAME} completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-central_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-central_functional/config.xml
@@ -114,7 +114,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Marionette ${PROJECT_NAME} testrun for ${BUILD_URL} on ${NODE_NAME} was aborted.
+            <body>Marionette ${PROJECT_NAME} testrun for ${INSTALLER_URL} on ${NODE_NAME} was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -146,7 +146,7 @@ ${BUILD_URL}</body>
       </configuredTriggers>
       <contentType>default</contentType>
       <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME} on ${NODE_NAME}</defaultSubject>
-      <defaultContent>Marionette ${PROJECT_NAME} testrun for ${BUILD_URL} on ${NODE_NAME} completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultContent>Marionette ${PROJECT_NAME} testrun for ${INSTALLER_URL} on ${NODE_NAME} completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/mozilla-central_update/config.xml
+++ b/jenkins-master/jobs/mozilla-central_update/config.xml
@@ -125,7 +125,7 @@ NSPR_LOG_FILE=http.log</propertiesContent>
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Marionette ${PROJECT_NAME} testrun for ${BUILD_URL} on ${NODE_NAME} was aborted.
+            <body>Marionette ${PROJECT_NAME} testrun for ${INSTALLER_URL} on ${NODE_NAME} was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -157,7 +157,7 @@ ${BUILD_URL}</body>
       </configuredTriggers>
       <contentType>default</contentType>
       <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME} on ${NODE_NAME}</defaultSubject>
-      <defaultContent>Marionette ${PROJECT_NAME} testrun for ${BUILD_URL} on ${NODE_NAME} completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultContent>Marionette ${PROJECT_NAME} testrun for ${INSTALLER_URL} on ${NODE_NAME} completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-beta_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_functional/config.xml
@@ -114,7 +114,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Marionette ${PROJECT_NAME} testrun for ${BUILD_URL} on ${NODE_NAME} was aborted.
+            <body>Marionette ${PROJECT_NAME} testrun for ${INSTALLER_URL} on ${NODE_NAME} was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -146,7 +146,7 @@ ${BUILD_URL}</body>
       </configuredTriggers>
       <contentType>default</contentType>
       <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME} on ${NODE_NAME}</defaultSubject>
-      <defaultContent>Marionette ${PROJECT_NAME} testrun for ${BUILD_URL} on ${NODE_NAME} completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultContent>Marionette ${PROJECT_NAME} testrun for ${INSTALLER_URL} on ${NODE_NAME} completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-esr38_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr38_functional/config.xml
@@ -114,7 +114,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Marionette ${PROJECT_NAME} testrun for ${BUILD_URL} on ${NODE_NAME} was aborted.
+            <body>Marionette ${PROJECT_NAME} testrun for ${INSTALLER_URL} on ${NODE_NAME} was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -146,7 +146,7 @@ ${BUILD_URL}</body>
       </configuredTriggers>
       <contentType>default</contentType>
       <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME} on ${NODE_NAME}</defaultSubject>
-      <defaultContent>Marionette ${PROJECT_NAME} testrun for ${BUILD_URL} on ${NODE_NAME} completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultContent>Marionette ${PROJECT_NAME} testrun for ${INSTALLER_URL} on ${NODE_NAME} completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}

--- a/jenkins-master/jobs/release-mozilla-release_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_functional/config.xml
@@ -114,7 +114,7 @@
           <email>
             <recipientList></recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <body>Marionette ${PROJECT_NAME} testrun for ${BUILD_URL} on ${NODE_NAME} was aborted.
+            <body>Marionette ${PROJECT_NAME} testrun for ${INSTALLER_URL} on ${NODE_NAME} was aborted.
 
 View the build in Jenkins:
 ${BUILD_URL}</body>
@@ -146,7 +146,7 @@ ${BUILD_URL}</body>
       </configuredTriggers>
       <contentType>default</contentType>
       <defaultSubject>[${BUILD_STATUS}] ${PROJECT_NAME} on ${NODE_NAME}</defaultSubject>
-      <defaultContent>Marionette ${PROJECT_NAME} testrun for ${BUILD_URL} on ${NODE_NAME} completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
+      <defaultContent>Marionette ${PROJECT_NAME} testrun for ${INSTALLER_URL} on ${NODE_NAME} completed with ${TEST_COUNTS, var=&quot;fail&quot;} failures.
 
 View the build in Jenkins:
 ${BUILD_URL}


### PR DESCRIPTION
Just a missing replacement of BUILD_URL with INSTALLER_URL from PR #654.