### PR TITLE
Fix accidentally added final 's' for target-buildid (#661)

### DIFF
--- a/jenkins-master/jobs/scripts/workspace/runtests.py
+++ b/jenkins-master/jobs/scripts/workspace/runtests.py
@@ -71,7 +71,7 @@ class Runner(object):
             if args.update_target_version:
                 command.extend(['--update-target-version', args.update_target_version])
             if args.update_target_build_id:
-                command.extend(['--update-target-buildids', args.update_target_build_id])
+                command.extend(['--update-target-buildid', args.update_target_build_id])
 
         elif args.type == 'functional':
             command.extend(['--gecko-log', settings['logs']['gecko.log']])


### PR DESCRIPTION
Another follow-up for issue #661. Looks like we all missed that extra 's' at the end of the --target-buildid command line option. @mjzffr can you please review?