### PR TITLE
Revert job names to avoid broken grouping in Treeherder (#661)

### DIFF
--- a/jenkins-master/jobs/scripts/workspace/config.py
+++ b/jenkins-master/jobs/scripts/workspace/config.py
@@ -11,9 +11,9 @@ config = {
     'test_types': {
         'functional': {
             'treeherder': {
-                'group_name': 'Firefox UI Tests - Functional',
+                'group_name': 'Firefox UI Tests - functional',
                 'group_symbol': 'Ff',
-                'job_name': '{locale}',
+                'job_name': 'Firefox UI Tests - functional ({locale})',
                 'job_symbol': '{locale}',
                 'tier': 3,
             },
@@ -24,9 +24,9 @@ config = {
         },
         'update': {
             'treeherder': {
-                'group_name': 'Firefox UI Tests - Update',
+                'group_name': 'Firefox UI Tests - update',
                 'group_symbol': 'Fu',
-                'job_name': '{locale}-{update_number}',
+                'job_name': 'Firefox UI Tests - update ({locale}-{update_number})',
                 'job_symbol': '{locale}-{update_number}',
                 'tier': 3,
             },


### PR DESCRIPTION
[Bug 1215587](https://bugzilla.mozilla.org/show_bug.cgi?id=1215587) prevents us from changing the job names. As result our functional jobs are getting sorted into the update group. We have to get this reverted. So this follow-up fixes it and reverts the change as done for issue #661.