### PR TITLE
get_mozharness has to checkout mozharness to a subdirectory (#691)

### DIFF
--- a/jenkins-master/config.xml
+++ b/jenkins-master/config.xml
@@ -234,7 +234,7 @@
           </default>
           <int>6</int>
           <string>MOZHARNESS_REVISION</string>
-          <string>9a8f2342fb31</string>
+          <string>49b1fe014eea</string>
           <string>MOZMILL_AUTOMATION_VERSION</string>
           <string>2.0.10.2</string>
           <string>NOTIFICATION_ADDRESS</string>

--- a/jenkins-master/jobs/get_mozharness/config.xml
+++ b/jenkins-master/jobs/get_mozharness/config.xml
@@ -26,12 +26,12 @@
   <builders>
     <hudson.tasks.Shell>
       <command>wget -Oarchiver_client.py --no-check-certificate --tries=10 --waitretry=3 https://hg.mozilla.org/build/tools/raw-file/default/buildfarm/utils/archiver_client.py
-python archiver_client.py mozharness --repo mozilla-central --rev $MOZHARNESS_REVISION --debug --destination .</command>
+python archiver_client.py mozharness --repo mozilla-central --rev $MOZHARNESS_REVISION --debug</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>
     <hudson.plugins.cloneworkspace.CloneWorkspacePublisher plugin="clone-workspace-scm@0.5">
-      <workspaceGlob></workspaceGlob>
+      <workspaceGlob>mozharness/**</workspaceGlob>
       <criteria>Successful</criteria>
       <archiveMethod>TAR</archiveMethod>
       <overrideDefaultExcludes>true</overrideDefaultExcludes>


### PR DESCRIPTION
This is the fix for issue #691.

@sydvicious or @mjzffr can one of you review please? I also updated the mozharness revision to include my fix for firefox-ui-tests to be able to run if cwd is not the mozharness root folder.