### PR TITLE
Update mozharness to rev e02b17a2b5b8 to fix download and symbols_url issues

### DIFF
--- a/jenkins-master/config.xml
+++ b/jenkins-master/config.xml
@@ -234,7 +234,7 @@
           </default>
           <int>6</int>
           <string>MOZHARNESS_REVISION</string>
-          <string>a18630f9ab42</string>
+          <string>e02b17a2b5b8</string>
           <string>MOZMILL_AUTOMATION_VERSION</string>
           <string>2.0.10.2</string>
           <string>NOTIFICATION_ADDRESS</string>


### PR DESCRIPTION
This PR includes a fix for the following issues:

* https://bugzilla.mozilla.org/show_bug.cgi?id=1229908 - ScriptMixin._urlopen() has to use quoted URL to not fail if spaces are contained
* https://bugzilla.mozilla.org/show_bug.cgi?id=1228644 - Created symbols_url is broken on Windows in case an installer is used 

@mjzffr or @sydvicious can one of you please review? Thanks.