### PR TITLE
Pass-through `test_packages_url` property (#722)

### DIFF
--- a/config/dev/pulse.json
+++ b/config/dev/pulse.json
@@ -37,6 +37,9 @@
                         },
                         "REVISION": {
                             "key": "revision"
+                        },
+                        "TEST_PACKAGES_URL": {
+                            "key": "test_packages_url"
                         }
                     },
                     "update": {
@@ -83,6 +86,9 @@
                         },
                         "REVISION": {
                             "key": "revision"
+                        },
+                        "TEST_PACKAGES_URL": {
+                            "key": "test_packages_url"
                         }
                     },
                     "update": {
@@ -128,6 +134,9 @@
                         },
                         "REVISION": {
                             "key": "revision"
+                        },
+                        "TEST_PACKAGES_URL": {
+                            "key": "test_packages_url"
                         }
                     }
                 }
@@ -165,6 +174,9 @@
                         },
                         "REVISION": {
                             "key": "revision"
+                        },
+                        "TEST_PACKAGES_URL": {
+                            "key": "test_packages_url"
                         }
                     }
                 }
@@ -201,6 +213,9 @@
                         },
                         "REVISION": {
                             "key": "revision"
+                        },
+                        "TEST_PACKAGES_URL": {
+                            "key": "test_packages_url"
                         }
                     }
                 }

--- a/config/production/pulse.json
+++ b/config/production/pulse.json
@@ -35,6 +35,9 @@
                         },
                         "REVISION": {
                             "key": "revision"
+                        },
+                        "TEST_PACKAGES_URL": {
+                            "key": "test_packages_url"
                         }
                     },
                     "update": {
@@ -82,6 +85,9 @@
                         },
                         "REVISION": {
                             "key": "revision"
+                        },
+                        "TEST_PACKAGES_URL": {
+                            "key": "test_packages_url"
                         }
                     },
                     "update": {
@@ -133,6 +139,9 @@
                         },
                         "REVISION": {
                             "key": "revision"
+                        },
+                        "TEST_PACKAGES_URL": {
+                            "key": "test_packages_url"
                         }
                     }
                 }
@@ -176,6 +185,9 @@
                         },
                         "REVISION": {
                             "key": "revision"
+                        },
+                        "TEST_PACKAGES_URL": {
+                            "key": "test_packages_url"
                         }
                     }
                 }
@@ -211,6 +223,9 @@
                         },
                         "REVISION": {
                             "key": "revision"
+                        },
+                        "TEST_PACKAGES_URL": {
+                            "key": "test_packages_url"
                         }
                     }
                 }

--- a/config/staging/pulse.json
+++ b/config/staging/pulse.json
@@ -36,6 +36,9 @@
                         },
                         "REVISION": {
                             "key": "revision"
+                        },
+                        "TEST_PACKAGES_URL": {
+                            "key": "test_packages_url"
                         }
                     },
                     "update": {
@@ -82,6 +85,9 @@
                         },
                         "REVISION": {
                             "key": "revision"
+                        },
+                        "TEST_PACKAGES_URL": {
+                            "key": "test_packages_url"
                         }
                     },
                     "update": {
@@ -126,6 +132,9 @@
                         },
                         "REVISION": {
                             "key": "revision"
+                        },
+                        "TEST_PACKAGES_URL": {
+                            "key": "test_packages_url"
                         }
                     }
                 }
@@ -162,6 +171,9 @@
                         },
                         "REVISION": {
                             "key": "revision"
+                        },
+                        "TEST_PACKAGES_URL": {
+                            "key": "test_packages_url"
                         }
                     }
                 }
@@ -198,6 +210,9 @@
                         },
                         "REVISION": {
                             "key": "revision"
+                        },
+                        "TEST_PACKAGES_URL": {
+                            "key": "test_packages_url"
                         }
                     }
                 }

--- a/jenkins-master/config.xml
+++ b/jenkins-master/config.xml
@@ -234,7 +234,7 @@
           </default>
           <int>6</int>
           <string>MOZHARNESS_REVISION</string>
-          <string>cfb5851c96ea</string>
+          <string>ea04fff1bfd4</string>
           <string>MOZMILL_AUTOMATION_VERSION</string>
           <string>2.0.10.2</string>
           <string>NOTIFICATION_ADDRESS</string>

--- a/jenkins-master/jobs/mozilla-aurora_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_functional/config.xml
@@ -35,6 +35,11 @@
           <description>The revision of Firefox which is used for the report to Treeherder.</description>
           <defaultValue>None</defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>TEST_PACKAGES_URL</name>
+          <description>The URL of the test_packages.json file for the given build.</description>
+          <defaultValue>None</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <EnvInjectJobProperty plugin="envinject@1.88">
@@ -72,7 +77,7 @@
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python -u runtests.py --test-type=functional --repository=mozilla-aurora --installer-url=$INSTALLER_URL</commandLine>
+      <commandLine>python -u runtests.py --test-type=functional --repository=mozilla-aurora --installer-url=$INSTALLER_URL --test-packages-url=$TEST_PACKAGES_URL</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/mozilla-aurora_update/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_update/config.xml
@@ -46,6 +46,11 @@
           <defaultValue>None</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
+          <name>TEST_PACKAGES_URL</name>
+          <description>The URL of the test_packages.json file for the given build.</description>
+          <defaultValue>None</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>UPDATE_NUMBER</name>
           <description>The number of the partial update: today - N days</description>
           <defaultValue>None</defaultValue>
@@ -89,7 +94,7 @@ NSPR_LOG_FILE=http.log</propertiesContent>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python -u runtests.py --test-type=update --repository=mozilla-aurora --installer-url=$INSTALLER_URL --update-channel=$CHANNEL --update-target-buildid=$TARGET_BUILD_ID</commandLine>
+      <commandLine>python -u runtests.py --test-type=update --repository=mozilla-aurora --installer-url=$INSTALLER_URL --test-packages-url=$TEST_PACKAGES_URL --update-channel=$CHANNEL --update-target-buildid=$TARGET_BUILD_ID</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/mozilla-central_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-central_functional/config.xml
@@ -35,6 +35,11 @@
           <description>The revision of Firefox which is used for the report to Treeherder.</description>
           <defaultValue>None</defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>TEST_PACKAGES_URL</name>
+          <description>The URL of the test_packages.json file for the given build.</description>
+          <defaultValue>None</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <EnvInjectJobProperty plugin="envinject@1.88">
@@ -72,7 +77,7 @@
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python -u runtests.py --test-type=functional --repository=mozilla-central --installer-url=$INSTALLER_URL</commandLine>
+      <commandLine>python -u runtests.py --test-type=functional --repository=mozilla-central --installer-url=$INSTALLER_URL --test-packages-url=$TEST_PACKAGES_URL</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/mozilla-central_update/config.xml
+++ b/jenkins-master/jobs/mozilla-central_update/config.xml
@@ -46,6 +46,11 @@
           <defaultValue>None</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
+          <name>TEST_PACKAGES_URL</name>
+          <description>The URL of the test_packages.json file for the given build.</description>
+          <defaultValue>None</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>UPDATE_NUMBER</name>
           <description>The number of the partial update: today - N days</description>
           <defaultValue>None</defaultValue>
@@ -89,7 +94,7 @@ NSPR_LOG_FILE=http.log</propertiesContent>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python -u runtests.py --test-type=update --repository=mozilla-central --installer-url=$INSTALLER_URL --update-channel=$CHANNEL --update-target-buildid=$TARGET_BUILD_ID</commandLine>
+      <commandLine>python -u runtests.py --test-type=update --repository=mozilla-central --installer-url=$INSTALLER_URL --test-packages-url=$TEST_PACKAGES_URL --update-channel=$CHANNEL --update-target-buildid=$TARGET_BUILD_ID</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/release-mozilla-beta_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-beta_functional/config.xml
@@ -35,6 +35,11 @@
           <description>The revision of Firefox which is used for the report to Treeherder.</description>
           <defaultValue>None</defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>TEST_PACKAGES_URL</name>
+          <description>The URL of the test_packages.json file for the given build.</description>
+          <defaultValue>None</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <EnvInjectJobProperty plugin="envinject@1.88">
@@ -72,7 +77,7 @@
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python -u runtests.py --test-type=functional --repository=mozilla-beta --installer-url=$INSTALLER_URL</commandLine>
+      <commandLine>python -u runtests.py --test-type=functional --repository=mozilla-beta --installer-url=$INSTALLER_URL --test-packages-url=$TEST_PACKAGES_URL</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/release-mozilla-esr38_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-esr38_functional/config.xml
@@ -35,6 +35,11 @@
           <description>The revision of Firefox which is used for the report to Treeherder.</description>
           <defaultValue>None</defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>TEST_PACKAGES_URL</name>
+          <description>The URL of the test_packages.json file for the given build.</description>
+          <defaultValue>None</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <EnvInjectJobProperty plugin="envinject@1.88">
@@ -72,7 +77,7 @@
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python -u runtests.py --test-type=functional --repository=mozilla-esr38 --installer-url=$INSTALLER_URL</commandLine>
+      <commandLine>python -u runtests.py --test-type=functional --repository=mozilla-esr38 --installer-url=$INSTALLER_URL --test-packages-url=$TEST_PACKAGES_URL</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/release-mozilla-release_functional/config.xml
+++ b/jenkins-master/jobs/release-mozilla-release_functional/config.xml
@@ -35,6 +35,11 @@
           <description>The revision of Firefox which is used for the report to Treeherder.</description>
           <defaultValue>None</defaultValue>
         </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
+          <name>TEST_PACKAGES_URL</name>
+          <description>The URL of the test_packages.json file for the given build.</description>
+          <defaultValue>None</defaultValue>
+        </hudson.model.StringParameterDefinition>
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <EnvInjectJobProperty plugin="envinject@1.88">
@@ -72,7 +77,7 @@
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python -u runtests.py --test-type=functional --repository=mozilla-release --installer-url=$INSTALLER_URL</commandLine>
+      <commandLine>python -u runtests.py --test-type=functional --repository=mozilla-release --installer-url=$INSTALLER_URL --test-packages-url=$TEST_PACKAGES_URL</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>

--- a/jenkins-master/jobs/scripts/workspace/runtests.py
+++ b/jenkins-master/jobs/scripts/workspace/runtests.py
@@ -38,17 +38,24 @@ class BaseRunner(object):
         :param settings: Settings for the Runner as retrieved from the config file.
         :param installer_url: URL of the build to download.
         :param repository: Name of the repository the build has been built from.
+        :param test_packages_url: The URL of the test_packages.json file for the given build.
         """
         self.installer_url = kwargs['installer_url']
         self.repository = kwargs['repository']
+        self.test_packages_url = kwargs['test_packages_url']
         self.settings = settings
 
     def query_args(self):
         """Returns all required and optional command line arguments."""
-        return [
+        args = [
             '--cfg', self.settings['harness_config'],
             '--installer-url', self.installer_url,
         ]
+
+        if self.test_packages_url:
+            args.extend(['--test-packages-url', self.test_packages_url])
+
+        return args
 
     def run(self):
         """Executes the tests.
@@ -148,6 +155,9 @@ def parse_args():
                         help='The URL of the build installer.')
     parser.add_argument('--repository',
                         help='The repository name the build was created from.')
+    parser.add_argument('--test-packages-url',
+                        action=JenkinsDefaultValueAction,
+                        help='The URL of the test_packages.json file for the given build.')
 
     update_group = parser.add_argument_group('Update Tests', 'Update test specific options')
     update_group.add_argument('--update-channel',

--- a/lib/automation.py
+++ b/lib/automation.py
@@ -176,6 +176,7 @@ class FirefoxAutomation:
         :param buildid: ID of the build.
         :param revision: Revision (changeset) of the build.
         :param tags: Build classification tags (e.g. nightly, l10n).
+        :param test_packages_url: URL to the test_packages.json file.
         :param version: Version of the build.
         :param status: Build status from Buildbot (build notifications only).
         :param target_buildid: ID of the build after the upgrade (update notification only).

--- a/lib/queues.py
+++ b/lib/queues.py
@@ -139,6 +139,7 @@ class NormalizedBuildQueue(PulseQueue):
             'revision': data['revision'],
             'status': data['status'],
             'tags': data['tags'],
+            'test_packages_url': data['test_packages_url'],
             'tree': data['tree'],
             'version': data['version'],
             'raw_json': data,

--- a/test/check_patches.sh
+++ b/test/check_patches.sh
@@ -4,7 +4,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 DIR_BASE=$(cd $(dirname ${BASH_SOURCE}); pwd)
-for ENVIRONMENT in staging production ; do
+for ENVIRONMENT in dev staging production ; do
   echo "Testing patch for $ENVIRONMENT"
   patch --directory=$DIR_BASE/.. --dry-run -p1 <$DIR_BASE/../config/$ENVIRONMENT/jenkins.patch || exit $?
 done


### PR DESCRIPTION
This PR fixes issue #722. @sydvicious and @mjzffr can you please review?

Before we can land this we need the mozharness patch landed on mozilla-central on [bug 1212609](https://bugzilla.mozilla.org/show_bug.cgi?id=1212609).

Here some example runs for all various types:

1. With the packed tests archive:
https://treeherder.allizom.org/logviewer.html#?job_id=2623823&repo=mozilla-central

2. Packaged tests from Github:
https://treeherder.allizom.org/logviewer.html#?job_id=2623899&repo=mozilla-central

3. Non-packaged tests from Github:
https://treeherder.allizom.org/logviewer.html#?job_id=2623898&repo=mozilla-central