### PR TITLE
Do not use test packages url for branches except mozilla-central (#722)

### DIFF
--- a/config/dev/pulse.json
+++ b/config/dev/pulse.json
@@ -86,9 +86,6 @@
                         },
                         "REVISION": {
                             "key": "revision"
-                        },
-                        "TEST_PACKAGES_URL": {
-                            "key": "test_packages_url"
                         }
                     },
                     "update": {
@@ -134,9 +131,6 @@
                         },
                         "REVISION": {
                             "key": "revision"
-                        },
-                        "TEST_PACKAGES_URL": {
-                            "key": "test_packages_url"
                         }
                     }
                 }
@@ -174,9 +168,6 @@
                         },
                         "REVISION": {
                             "key": "revision"
-                        },
-                        "TEST_PACKAGES_URL": {
-                            "key": "test_packages_url"
                         }
                     }
                 }
@@ -213,9 +204,6 @@
                         },
                         "REVISION": {
                             "key": "revision"
-                        },
-                        "TEST_PACKAGES_URL": {
-                            "key": "test_packages_url"
                         }
                     }
                 }

--- a/config/production/pulse.json
+++ b/config/production/pulse.json
@@ -85,9 +85,6 @@
                         },
                         "REVISION": {
                             "key": "revision"
-                        },
-                        "TEST_PACKAGES_URL": {
-                            "key": "test_packages_url"
                         }
                     },
                     "update": {
@@ -139,9 +136,6 @@
                         },
                         "REVISION": {
                             "key": "revision"
-                        },
-                        "TEST_PACKAGES_URL": {
-                            "key": "test_packages_url"
                         }
                     }
                 }
@@ -185,9 +179,6 @@
                         },
                         "REVISION": {
                             "key": "revision"
-                        },
-                        "TEST_PACKAGES_URL": {
-                            "key": "test_packages_url"
                         }
                     }
                 }
@@ -223,9 +214,6 @@
                         },
                         "REVISION": {
                             "key": "revision"
-                        },
-                        "TEST_PACKAGES_URL": {
-                            "key": "test_packages_url"
                         }
                     }
                 }

--- a/config/staging/pulse.json
+++ b/config/staging/pulse.json
@@ -85,9 +85,6 @@
                         },
                         "REVISION": {
                             "key": "revision"
-                        },
-                        "TEST_PACKAGES_URL": {
-                            "key": "test_packages_url"
                         }
                     },
                     "update": {
@@ -132,9 +129,6 @@
                         },
                         "REVISION": {
                             "key": "revision"
-                        },
-                        "TEST_PACKAGES_URL": {
-                            "key": "test_packages_url"
                         }
                     }
                 }
@@ -171,9 +165,6 @@
                         },
                         "REVISION": {
                             "key": "revision"
-                        },
-                        "TEST_PACKAGES_URL": {
-                            "key": "test_packages_url"
                         }
                     }
                 }
@@ -210,9 +201,6 @@
                         },
                         "REVISION": {
                             "key": "revision"
-                        },
-                        "TEST_PACKAGES_URL": {
-                            "key": "test_packages_url"
                         }
                     }
                 }


### PR DESCRIPTION
Follow-up patch to fix the bustage for older branches than mozilla-central. @sydvicious or @mjzffr can you please review?

Please note that I left in the TEST_PACKAGE_URL parameter for all branches. If you think I should remove it too, please let me know. I think at leat for esr38 we can do that because it will never get such a package. For the others it would make it easier for the next merges, so we only have to re-add the lines in the pulse configs.