### PR TITLE
Unit tests fail with: AttributeError: 'NoneType' object has no attribute 'close' (#731)

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -88,7 +88,7 @@ def run_tests():
     try:
         venv = VirtualEnv()
         venv.activate()
-        venv.run('pip', 'install', 'selenium')
+        venv.run('pip', 'install', 'selenium==2.48.0')
 
         jenkins.wait_for_started()
         venv.run('python', 'test/configuration/save_config.py')


### PR DESCRIPTION
This PR will fix issue #731 by pinning to the former release.