### PR TITLE
Bump mozharnes for unzip workaround on bug 1241061 (#737)

### DIFF
--- a/jenkins-master/config.xml
+++ b/jenkins-master/config.xml
@@ -234,7 +234,7 @@
           </default>
           <int>6</int>
           <string>MOZHARNESS_REVISION</string>
-          <string>71dec72dcdd5</string>
+          <string>7104d650a97d</string>
           <string>MOZMILL_AUTOMATION_VERSION</string>
           <string>2.0.10.2</string>
           <string>NOTIFICATION_ADDRESS</string>


### PR DESCRIPTION
Fix for issue #737 to get test packaged builds working on Windows nodes without unzip installed.