### PR TITLE
Use Treeherder instead of hg-mo to query for Tinderbox builds (#738)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,17 @@ mozdownload==1.20.2
 mozprocess==0.22
 python-jenkins==0.4.8
 redo==1.5
-requests==2.7.0
+requests==2.9.1
 taskcluster==0.0.24
+treeherder-client==2.0.1
 
 # https://github.com/mozilla/mozmill-ci/issues/628
 # As long as Python 2.7.10 cannot be used on our master machines
 ndg-httpsclient
 pyasn1
 pyopenssl
+
+# Required by treeherder-client
+mohawk==0.3.0
+requests-hawk==1.0.0
+six==1.10.0


### PR DESCRIPTION
This is part II for issue #738 which will change the crawling from hg.mo to Treeherder. 