### PR TITLE
Use a fixed mozharness version of mozilla-esr45 for mozilla-esr38 branch (#770)

### DIFF
--- a/jenkins-master/jobs/scripts/workspace/runtests.py
+++ b/jenkins-master/jobs/scripts/workspace/runtests.py
@@ -77,9 +77,9 @@ class BaseRunner(object):
             repository = self.repository
         elif self.repository == 'mozilla-esr38':
             # On mozilla-esr38 we do not have a mozharness script for our fx ui tests.
-            # Fake it by getting the latest mozharness scripts from 45.0ESR instead.
+            # Fake it by getting a known version of mozharness from 45.0ESR instead.
             repository = 'releases/mozilla-esr45'
-            revision = 'default'
+            revision = '226acde614dc'
         else:
             repository = 'releases/{}'.format(self.repository)
 


### PR DESCRIPTION
This PR fixes issue #770 by not retrieving the latest mozharness version but a fixed one which is known to work. This will only exist for the next two releases and then be gone.