### PR TITLE
Use branch of *target* instead of source build

### DIFF
--- a/jenkins-master/jobs/trigger-ondemand/workspace/trigger.py
+++ b/jenkins-master/jobs/trigger-ondemand/workspace/trigger.py
@@ -228,7 +228,7 @@ def main():
                 build_details.update({'locale': locale})
 
                 parameters = {
-                    'BRANCH': build_details['branch'],
+                    'BRANCH': testrun['branch'],
                     'INSTALLER_URL': get_installer_url(build_details),
                     'LOCALE': locale,
                     'NODES': ' && '.join(node_labels),


### PR DESCRIPTION
I tested with manual triggering of an update job that for RC builds (the only case where the repository/branch of the target and source builds differs), the ondemand_update jobs run correctly with the "mozilla-release" (target) instead of the "mozilla-beta" (source) branch name handed over.

A failing job triggered before this change is http://mm-ci-production.qa.scl3.mozilla.com:8080/job/ondemand_update/26069/console
A manual try with different branch is http://mm-ci-production.qa.scl3.mozilla.com:8080/job/ondemand_update/26070/console (and it's also green on treeherder)

The config fed to trigger-ondemand that causes the failures is https://wiki.mozilla.org/QA/Desktop_Firefox/Releases/Configs/Fx46RC1

If I see things correctly, line 198 ends up assigning the *target* build's branch to testrun['branch'] so we can use that instead of build_details['branch'] which is derived from /entry/ which is the source build's version.