### PR TITLE
Bump quiet period for nightly update jobs to 5 minutes (#778)

### DIFF
--- a/jenkins-master/jobs/mozilla-aurora_update/config.xml
+++ b/jenkins-master/jobs/mozilla-aurora_update/config.xml
@@ -71,7 +71,7 @@ NSPR_LOG_FILE=http.log</propertiesContent>
     </EnvInjectJobProperty>
   </properties>
   <scm class="hudson.scm.NullSCM"/>
-  <quietPeriod>60</quietPeriod>
+  <quietPeriod>300</quietPeriod>
   <canRoam>true</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/jenkins-master/jobs/mozilla-central_update/config.xml
+++ b/jenkins-master/jobs/mozilla-central_update/config.xml
@@ -71,7 +71,7 @@ NSPR_LOG_FILE=http.log</propertiesContent>
     </EnvInjectJobProperty>
   </properties>
   <scm class="hudson.scm.NullSCM"/>
-  <quietPeriod>60</quietPeriod>
+  <quietPeriod>300</quietPeriod>
   <canRoam>true</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>


### PR DESCRIPTION
This is a follow-up fix for issue #778. The current quiet period is not long enough, so bumping it for safety to full 5 minutes.