### PR TITLE
Stop running tests for OS X 10.6 on mozilla-beta (#790)

### DIFF
--- a/config/dev/pulse.json
+++ b/config/dev/pulse.json
@@ -294,7 +294,6 @@
                         "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
-                        "mac && 10.6 && 64bit",
                         "mac && 10.9 && 64bit",
                         "mac && 10.10 && 64bit",
                         "mac && 10.11 && 64bit"

--- a/config/production/pulse.json
+++ b/config/production/pulse.json
@@ -318,7 +318,6 @@
                         "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
-                        "mac && 10.6 && 64bit",
                         "mac && 10.9 && 64bit",
                         "mac && 10.10 && 64bit",
                         "mac && 10.11 && 64bit"

--- a/config/staging/pulse.json
+++ b/config/staging/pulse.json
@@ -306,7 +306,6 @@
                         "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
-                        "mac && 10.6 && 64bit",
                         "mac && 10.9 && 64bit",
                         "mac && 10.10 && 64bit",
                         "mac && 10.11 && 64bit"


### PR DESCRIPTION
This PR is the second last patch in the series to unsupport OS X 10.6 (issue #790). We will need this active in mozmill-ci in about two weeks. To be ready for the switch I would like to have this reviewed already now.

@mjzffr can you please have a look? Thanks.