### PR TITLE
Allow to run different build types for mozilla-central jobs

### DIFF
--- a/jenkins-master/jobs/mozilla-central_functional/config.xml
+++ b/jenkins-master/jobs/mozilla-central_functional/config.xml
@@ -31,6 +31,11 @@
           <defaultValue></defaultValue>
         </org.jvnet.jenkins.plugins.nodelabelparameter.LabelParameterDefinition>
         <hudson.model.StringParameterDefinition>
+          <name>REPOSITORY</name>
+          <description>The repository of Firefox.</description>
+          <defaultValue>mozilla-central</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>REVISION</name>
           <description>The revision of Firefox which is used for the report to Treeherder.</description>
           <defaultValue>None</defaultValue>
@@ -70,11 +75,11 @@
       </selector>
     </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python -u submission.py --test-type=functional --build-state=running --repository=mozilla-central --revision=$REVISION --locale=$LOCALE</commandLine>
+      <commandLine>python -u submission.py --test-type=functional --build-state=running --repository=$REPOSITORY --revision=$REVISION --locale=$LOCALE</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python -u runtests.py --test-type=functional --repository=mozilla-central --revision=$REVISION --installer-url=$INSTALLER_URL --test-packages-url=$TEST_PACKAGES_URL</commandLine>
+      <commandLine>python -u runtests.py --test-type=functional --repository=$REPOSITORY --revision=$REVISION --installer-url=$INSTALLER_URL --test-packages-url=$TEST_PACKAGES_URL</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>
@@ -89,7 +94,7 @@
     <org.jenkinsci.plugins.postbuildscript.PostBuildScript plugin="postbuildscript@0.17">
       <buildSteps>
         <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-          <commandLine>python -u submission.py --test-type=functional --build-state=completed --repository=mozilla-central --revision=$REVISION --locale=$LOCALE</commandLine>
+          <commandLine>python -u submission.py --test-type=functional --build-state=completed --repository=$REPOSITORY --revision=$REVISION --locale=$LOCALE</commandLine>
           <executeFromWorkingDir>false</executeFromWorkingDir>
         </hudson.plugins.xshell.XShellBuilder>
       </buildSteps>

--- a/jenkins-master/jobs/mozilla-central_update/config.xml
+++ b/jenkins-master/jobs/mozilla-central_update/config.xml
@@ -36,6 +36,11 @@
           <defaultValue></defaultValue>
         </org.jvnet.jenkins.plugins.nodelabelparameter.LabelParameterDefinition>
         <hudson.model.StringParameterDefinition>
+          <name>REPOSITORY</name>
+          <description>The repository of Firefox.</description>
+          <defaultValue>$REPOSITORY</defaultValue>
+        </hudson.model.StringParameterDefinition>
+        <hudson.model.StringParameterDefinition>
           <name>REVISION</name>
           <description>The expected revision of Firefox after the upgrade, which is also used for the report to Treeherder.</description>
           <defaultValue>None</defaultValue>
@@ -88,11 +93,11 @@ NSPR_LOG_FILE=http.log</propertiesContent>
       </selector>
     </hudson.plugins.copyartifact.CopyArtifact>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python -u submission.py --test-type=update --build-state=running --repository=mozilla-central --revision=$REVISION --locale=$LOCALE --update-channel=$CHANNEL --update-number=$UPDATE_NUMBER</commandLine>
+      <commandLine>python -u submission.py --test-type=update --build-state=running --repository=$REPOSITORY --revision=$REVISION --locale=$LOCALE --update-channel=$CHANNEL --update-number=$UPDATE_NUMBER</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
     <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-      <commandLine>python -u runtests.py --test-type=update --repository=mozilla-central --revision=$REVISION --installer-url=$INSTALLER_URL --test-packages-url=$TEST_PACKAGES_URL --update-channel=$CHANNEL --update-target-buildid=$TARGET_BUILD_ID</commandLine>
+      <commandLine>python -u runtests.py --test-type=update --repository=$REPOSITORY --revision=$REVISION --installer-url=$INSTALLER_URL --test-packages-url=$TEST_PACKAGES_URL --update-channel=$CHANNEL --update-target-buildid=$TARGET_BUILD_ID</commandLine>
       <executeFromWorkingDir>false</executeFromWorkingDir>
     </hudson.plugins.xshell.XShellBuilder>
   </builders>
@@ -107,7 +112,7 @@ NSPR_LOG_FILE=http.log</propertiesContent>
     <org.jenkinsci.plugins.postbuildscript.PostBuildScript plugin="postbuildscript@0.17">
       <buildSteps>
         <hudson.plugins.xshell.XShellBuilder plugin="xshell@0.9-SNAPSHOT">
-          <commandLine>python -u submission.py --test-type=update --build-state=completed --repository=mozilla-central --revision=$REVISION --locale=$LOCALE --update-channel=$CHANNEL --update-number=$UPDATE_NUMBER</commandLine>
+          <commandLine>python -u submission.py --test-type=update --build-state=completed --repository=$REPOSITORY --revision=$REVISION --locale=$LOCALE --update-channel=$CHANNEL --update-number=$UPDATE_NUMBER</commandLine>
           <executeFromWorkingDir>false</executeFromWorkingDir>
         </hudson.plugins.xshell.XShellBuilder>
       </buildSteps>

--- a/jenkins-master/jobs/scripts/workspace/runtests.py
+++ b/jenkins-master/jobs/scripts/workspace/runtests.py
@@ -78,10 +78,12 @@ class BaseRunner(object):
         # to add the `releases/` prefix for each repository except mozilla-central.
         revision = self.revision
 
-        if self.repository == 'mozilla-central':
+        if self.repository in ('mozilla-central', 'mozilla-unified', 'try'):
             repository = self.repository
-        else:
+        elif self.repository.startswith('mozilla-'):
             repository = 'releases/{}'.format(self.repository)
+        else:
+            repository = 'integration/{}'.format(self.repository)
 
         command = [
             'python', 'archiver_client.py',


### PR DESCRIPTION
This is the fix for issue #810. @mjzffr mind reviewing it? Thanks.