### PR TITLE
Stop running tests for OS X 10.6 on mozilla-beta

### DIFF
--- a/config/dev/pulse.json
+++ b/config/dev/pulse.json
@@ -323,7 +323,6 @@
                         "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
-                        "mac && 10.6 && 64bit",
                         "mac && 10.9 && 64bit",
                         "mac && 10.10 && 64bit",
                         "mac && 10.11 && 64bit"

--- a/config/production/pulse.json
+++ b/config/production/pulse.json
@@ -347,7 +347,6 @@
                         "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
-                        "mac && 10.6 && 64bit",
                         "mac && 10.9 && 64bit",
                         "mac && 10.10 && 64bit",
                         "mac && 10.11 && 64bit"

--- a/config/staging/pulse.json
+++ b/config/staging/pulse.json
@@ -336,7 +336,6 @@
                         "linux && ubuntu && 14.04 && 64bit"
                     ],
                     "mac": [
-                        "mac && 10.6 && 64bit",
                         "mac && 10.9 && 64bit",
                         "mac && 10.10 && 64bit",
                         "mac && 10.11 && 64bit"


### PR DESCRIPTION
This removes the execution of tests for OS X 10.6 for the next release build of Firefox (issue #790). @mjzffr can you please review? Thanks.