### PR TITLE
Disable tests on Windows XP for mozilla-central (#829)

### DIFF
--- a/config/dev/pulse.json
+++ b/config/dev/pulse.json
@@ -264,7 +264,6 @@
                         "mac && 10.11 && 64bit"
                     ],
                     "win32": [
-                        "windows && xp && 32bit",
                         "windows && 7 && 32bit",
                         "windows && 7 && 64bit",
                         "windows && 8.1 && 32bit",

--- a/config/production/pulse.json
+++ b/config/production/pulse.json
@@ -288,7 +288,6 @@
                         "mac && 10.11 && 64bit"
                     ],
                     "win32": [
-                        "windows && xp && 32bit",
                         "windows && 7 && 32bit",
                         "windows && 7 && 64bit",
                         "windows && 8.1 && 32bit",

--- a/config/staging/pulse.json
+++ b/config/staging/pulse.json
@@ -275,7 +275,6 @@
                         "mac && 10.11 && 64bit"
                     ],
                     "win32": [
-                        "windows && xp && 32bit",
                         "windows && 7 && 32bit",
                         "windows && 7 && 64bit",
                         "windows && 8.1 && 32bit",


### PR DESCRIPTION
We have to disable Windows XP for Aurora now given that the merge happened yesterday, and tests are busted now on that platform for Firefox 53.

Fixes partly issue #829.